### PR TITLE
docs: add Good First Issues section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ DevCard uses a three-layer follow engine:
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions, coding standards, and PR process.
 
+## Good First Issues
+
+New to open source? We've got you covered! Check out our [Good First Issues](https://github.com/Dev-Card/DevCard/issues?q=is%3Aopen+label%3A%22good+first+issue%22) — these are specially curated issues that are:
+
+- Well-documented with clear acceptance criteria
+- Limited in scope (perfect for a first contribution)
+- Mentored by maintainers
+
+### How to Claim an Issue
+
+1. Browse the [Good First Issues list](https://github.com/Dev-Card/DevCard/issues?q=is%3Aopen+label%3A%22good+first+issue%22)
+2. Comment on the issue you'd like to work on (e.g., "I'd like to take this on!")
+3. Wait for a maintainer to assign it to you
+4. Fork the repo, make your changes, and open a PR
+
+That's it! We're here to help you succeed.
+
 ## License
 
 DevCard is licensed under the [Apache License 2.0](./LICENSE).


### PR DESCRIPTION
## Summary
Adds a dedicated 'Good First Issues' section to the README as requested in #18.

## Changes
- Added `## Good First Issues` section under Contributing
- Linked to the good first issues search with proper label filter
- Provided clear, beginner-friendly instructions for claiming issues

## Acceptance Criteria
- [x] Section exists and is helpful for first-time contributors

Closes #18