### PR TITLE
feat: add copy-to-clipboard toast feedback on profile pages

### DIFF
--- a/apps/web/src/routes/devcard/[id]/+page.svelte
+++ b/apps/web/src/routes/devcard/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { PLATFORMS } from '@devcard/shared';
 
 	let { data } = $props();
@@ -37,9 +38,11 @@
 				showToast('Failed to copy. Please copy manually.');
 			}
 		} else {
-			window.open(link.url, '_blank');
+			window.open(link.url, '_blank', 'noopener,noreferrer');
 		}
 	}
+
+	onDestroy(() => { if (toastTimer) clearTimeout(toastTimer); });
 </script>
 
 <svelte:head>
@@ -123,11 +126,8 @@
 	</div>
 </div>
 
-<!-- Accessible live region for copy feedback -->
-<div aria-live="polite" aria-atomic="true" class="sr-only">{toastMessage}</div>
-
 {#if toastMessage}
-	<div class="toast" role="status">{toastMessage}</div>
+	<div class="toast" role="status" aria-live="polite" aria-atomic="true">{toastMessage}</div>
 {/if}
 
 <style>
@@ -381,15 +381,5 @@
 		pointer-events: none;
 	}
 
-	.sr-only {
-		position: absolute;
-		width: 1px;
-		height: 1px;
-		padding: 0;
-		margin: -1px;
-		overflow: hidden;
-		clip: rect(0, 0, 0, 0);
-		white-space: nowrap;
-		border: 0;
-	}
+
 </style>

--- a/apps/web/src/routes/devcard/[id]/+page.svelte
+++ b/apps/web/src/routes/devcard/[id]/+page.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
+	import { PLATFORMS } from '@devcard/shared';
+
 	let { data } = $props();
 	const card = $derived(data.card);
+
+	let toastMessage = $state('');
+	let toastTimer: ReturnType<typeof setTimeout> | null = null;
 
 	function getPlatformColor(platform: string) {
 		const colors: Record<string, string> = {
@@ -10,13 +15,30 @@
 			instagram: '#E4405F',
 			youtube: '#FF0000',
 			devto: '#0A0A0A',
-			hashnode: '#2962FF'
+			hashnode: '#2962FF',
+			discord: '#5865F2',
 		};
 		return colors[platform.toLowerCase()] || '#6366F1';
 	}
 
-	function handlePlatformClick(link: any) {
-		window.open(link.url, '_blank');
+	function showToast(message: string) {
+		toastMessage = message;
+		if (toastTimer) clearTimeout(toastTimer);
+		toastTimer = setTimeout(() => { toastMessage = ''; }, 3000);
+	}
+
+	async function handlePlatformClick(link: any) {
+		const platform = PLATFORMS[link.platform];
+		if (platform?.followStrategy === 'copy') {
+			try {
+				await navigator.clipboard.writeText(link.username);
+				showToast('Copied to clipboard!');
+			} catch {
+				showToast('Failed to copy. Please copy manually.');
+			}
+		} else {
+			window.open(link.url, '_blank');
+		}
 	}
 </script>
 
@@ -100,6 +122,13 @@
 		</footer>
 	</div>
 </div>
+
+<!-- Accessible live region for copy feedback -->
+<div aria-live="polite" aria-atomic="true" class="sr-only">{toastMessage}</div>
+
+{#if toastMessage}
+	<div class="toast" role="status">{toastMessage}</div>
+{/if}
 
 <style>
 	:global(body) {
@@ -333,5 +362,34 @@
 		color: #6366F1;
 		text-decoration: none;
 		font-weight: 600;
+	}
+
+	.toast {
+		position: fixed;
+		bottom: 1.5rem;
+		left: 50%;
+		transform: translateX(-50%);
+		background: #1e293b;
+		color: #f8fafc;
+		border: 1px solid #334155;
+		border-radius: 8px;
+		padding: 0.625rem 1.25rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+		z-index: 1000;
+		pointer-events: none;
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
 	}
 </style>

--- a/apps/web/src/routes/u/[username]/+page.svelte
+++ b/apps/web/src/routes/u/[username]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { PLATFORMS, getProfileUrl } from '@devcard/shared';
 
   let { data } = $props();
@@ -30,6 +31,8 @@
       showToast('Failed to copy. Please copy manually.');
     }
   }
+
+  onDestroy(() => { if (toastTimer) clearTimeout(toastTimer); });
 </script>
 
 <svelte:head>
@@ -132,11 +135,8 @@
     </footer>
   </main>
 
-  <!-- Accessible live region for copy feedback -->
-  <div aria-live="polite" aria-atomic="true" class="sr-only">{toastMessage}</div>
-
   {#if toastMessage}
-    <div class="toast" role="status">{toastMessage}</div>
+    <div class="toast" role="status" aria-live="polite" aria-atomic="true">{toastMessage}</div>
   {/if}
 {/if}
 
@@ -348,7 +348,7 @@
 
   /* Copy button — matches anchor tile styles */
   button.platform-tile {
-    background: none;
+    background: var(--bg-elevated);
     border: 1px solid var(--border);
     cursor: pointer;
     font: inherit;
@@ -374,16 +374,5 @@
     pointer-events: none;
   }
 
-  /* Visually hidden but available to screen readers */
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
+
 </style>

--- a/apps/web/src/routes/u/[username]/+page.svelte
+++ b/apps/web/src/routes/u/[username]/+page.svelte
@@ -12,6 +12,24 @@
     leetcode: '#FFA116', hackerrank: '#00EA64', discord: '#5865F2',
     telegram: '#26A5E4', email: '#EA4335', portfolio: '#6366F1', custom: '#8B5CF6',
   };
+
+  let toastMessage = $state('');
+  let toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function showToast(message: string) {
+    toastMessage = message;
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => { toastMessage = ''; }, 3000);
+  }
+
+  async function handleCopy(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+      showToast('Copied to clipboard!');
+    } catch {
+      showToast('Failed to copy. Please copy manually.');
+    }
+  }
 </script>
 
 <svelte:head>
@@ -66,21 +84,39 @@
         {#each profile.links as link}
           {@const platform = PLATFORMS[link.platform]}
           {@const color = platformColors[link.platform] || '#6366f1'}
-          <a
-            href={link.url || getProfileUrl(link.platform, link.username)}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="platform-tile"
-          >
-            <div class="tile-icon" style="background: {color}">
-              {platform?.name.charAt(0) || '?'}
-            </div>
-            <div class="tile-info">
-              <span class="tile-name">{platform?.name || link.platform}</span>
-              <span class="tile-username">{link.username}</span>
-            </div>
-            <span class="tile-arrow">→</span>
-          </a>
+          {@const isCopy = platform?.followStrategy === 'copy'}
+          {#if isCopy}
+            <button
+              class="platform-tile"
+              onclick={() => handleCopy(link.username)}
+              aria-label="Copy {platform?.name || link.platform} username to clipboard"
+            >
+              <div class="tile-icon" style="background: {color}">
+                {platform?.name.charAt(0) || '?'}
+              </div>
+              <div class="tile-info">
+                <span class="tile-name">{platform?.name || link.platform}</span>
+                <span class="tile-username">{link.username}</span>
+              </div>
+              <span class="tile-arrow">⎘</span>
+            </button>
+          {:else}
+            <a
+              href={link.url || getProfileUrl(link.platform, link.username)}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="platform-tile"
+            >
+              <div class="tile-icon" style="background: {color}">
+                {platform?.name.charAt(0) || '?'}
+              </div>
+              <div class="tile-info">
+                <span class="tile-name">{platform?.name || link.platform}</span>
+                <span class="tile-username">{link.username}</span>
+              </div>
+              <span class="tile-arrow">→</span>
+            </a>
+          {/if}
         {/each}
       </div>
     </div>
@@ -95,6 +131,13 @@
       Powered by <a href="/">DevCard</a> — Open Source Developer Profiles
     </footer>
   </main>
+
+  <!-- Accessible live region for copy feedback -->
+  <div aria-live="polite" aria-atomic="true" class="sr-only">{toastMessage}</div>
+
+  {#if toastMessage}
+    <div class="toast" role="status">{toastMessage}</div>
+  {/if}
 {/if}
 
 <style>
@@ -301,5 +344,46 @@
   @media (max-width: 500px) {
     .profile-page { padding: 1rem 0.75rem; }
     .display-name { font-size: 1.5rem; }
+  }
+
+  /* Copy button — matches anchor tile styles */
+  button.platform-tile {
+    background: none;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+    width: 100%;
+  }
+
+  /* Toast notification */
+  .toast {
+    position: fixed;
+    bottom: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1e293b;
+    color: #f8fafc;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    padding: 0.625rem 1.25rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    z-index: 1000;
+    pointer-events: none;
+  }
+
+  /* Visually hidden but available to screen readers */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 </style>


### PR DESCRIPTION
## Summary

Adds success/failure toast feedback for copy-to-clipboard actions on both public profile pages.

### Changes

**`apps/web/src/routes/u/[username]/+page.svelte`**
- Detects platforms with `followStrategy === 'copy'` (e.g. Discord, which has no profile URL) and renders a `<button>` tile instead of an `<a>` link
- Clicking the button calls `navigator.clipboard.writeText(username)` and shows a toast
- On failure (e.g. HTTP context), shows "Failed to copy. Please copy manually."
- Toast auto-dismisses after 3 seconds

**`apps/web/src/routes/devcard/[id]/+page.svelte`**
- Imports `PLATFORMS` from `@devcard/shared` and checks `followStrategy` in `handlePlatformClick`
- `'copy'` strategy → clipboard copy + toast; all others → `window.open` (unchanged)

**Both pages include:**
- `<div aria-live="polite" aria-atomic="true" class="sr-only">` — announces the message to screen readers
- `<div role="status" class="toast">` — visible 3-second popup at bottom-center
- CSS for toast (fixed position, dark themed) and `.sr-only` utility class

Closes #20

## Test plan

- [ ] Navigate to a profile with a Discord link → tile shows a copy icon (⎘) instead of →
- [ ] Click Discord tile → "Copied to clipboard!" toast appears for 3 seconds
- [ ] Paste in another app → correct username is pasted
- [ ] All other platform tiles (GitHub, LinkedIn, etc.) still open links in new tab
- [ ] Screen reader announces the copy feedback via the aria-live region
- [ ] No console errors on any interaction