### PR TITLE
feat: add isSupportedPlatform helper and URL function unit tests

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "vitest": "^1.6.0"
+    "vitest": "^2.0.0"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,9 +7,11 @@
   "types": "./src/index.ts",
   "scripts": {
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/shared/src/__tests__/platforms-url.test.ts
+++ b/packages/shared/src/__tests__/platforms-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { getProfileUrl, getWebViewUrl, getDeepLinkUrl } from '../platforms';
+
+describe('getProfileUrl', () => {
+  it('returns the correct GitHub profile URL', () => {
+    expect(getProfileUrl('github', 'octocat')).toBe('https://github.com/octocat');
+  });
+
+  it('returns the correct LinkedIn profile URL', () => {
+    expect(getProfileUrl('linkedin', 'johndoe')).toBe('https://www.linkedin.com/in/johndoe');
+  });
+
+  it('returns empty string for an unknown platform', () => {
+    expect(getProfileUrl('unknown', 'x')).toBe('');
+  });
+});
+
+describe('getWebViewUrl', () => {
+  it('returns the LinkedIn webview URL', () => {
+    expect(getWebViewUrl('linkedin', 'johndoe')).toBe('https://www.linkedin.com/in/johndoe');
+  });
+
+  it('returns null for github (no webview URL)', () => {
+    expect(getWebViewUrl('github', 'octocat')).toBeNull();
+  });
+});
+
+describe('getDeepLinkUrl', () => {
+  it('returns the Twitter deep link URL', () => {
+    expect(getDeepLinkUrl('twitter', 'elonmusk')).toBe('twitter://user?screen_name=elonmusk');
+  });
+
+  it('returns null for github (no deep link)', () => {
+    expect(getDeepLinkUrl('github', 'octocat')).toBeNull();
+  });
+});

--- a/packages/shared/src/__tests__/platforms.test.ts
+++ b/packages/shared/src/__tests__/platforms.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { isSupportedPlatform } from '../platforms';
+
+describe('isSupportedPlatform', () => {
+  it('returns true for github', () => {
+    expect(isSupportedPlatform('github')).toBe(true);
+  });
+
+  it('returns true for linkedin', () => {
+    expect(isSupportedPlatform('linkedin')).toBe(true);
+  });
+
+  it('returns false for myspace (unknown platform)', () => {
+    expect(isSupportedPlatform('myspace')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isSupportedPlatform('')).toBe(false);
+  });
+
+  it('returns false for GITHUB (case-sensitive check)', () => {
+    expect(isSupportedPlatform('GITHUB')).toBe(false);
+  });
+});

--- a/packages/shared/src/__tests__/platforms.test.ts
+++ b/packages/shared/src/__tests__/platforms.test.ts
@@ -21,4 +21,10 @@ describe('isSupportedPlatform', () => {
   it('returns false for GITHUB (case-sensitive check)', () => {
     expect(isSupportedPlatform('GITHUB')).toBe(false);
   });
+
+  it('returns false for inherited Object prototype keys like toString', () => {
+    expect(isSupportedPlatform('toString')).toBe(false);
+    expect(isSupportedPlatform('constructor')).toBe(false);
+    expect(isSupportedPlatform('__proto__')).toBe(false);
+  });
 });

--- a/packages/shared/src/platforms.ts
+++ b/packages/shared/src/platforms.ts
@@ -277,5 +277,5 @@ export function getDeepLinkUrl(platformId: string, username: string): string | n
 
 /** Returns true if the given id corresponds to a registered platform */
 export function isSupportedPlatform(id: string): boolean {
-  return PLATFORMS[id] !== undefined;
+  return Object.prototype.hasOwnProperty.call(PLATFORMS, id);
 }

--- a/packages/shared/src/platforms.ts
+++ b/packages/shared/src/platforms.ts
@@ -274,3 +274,8 @@ export function getDeepLinkUrl(platformId: string, username: string): string | n
   if (!platform?.deepLinkPattern) return null;
   return platform.deepLinkPattern.replace(/{username}/g, username);
 }
+
+/** Returns true if the given id corresponds to a registered platform */
+export function isSupportedPlatform(id: string): boolean {
+  return PLATFORMS[id] !== undefined;
+}


### PR DESCRIPTION
## Summary

- Add `isSupportedPlatform(id: string): boolean` helper to `packages/shared/src/platforms.ts` that checks if a given platform ID exists in the registry
- Add `packages/shared/src/__tests__/platforms.test.ts` with vitest tests covering known IDs (`github`, `linkedin`), unknown IDs (`myspace`), empty string, and case-sensitivity
- Add `packages/shared/src/__tests__/platforms-url.test.ts` with vitest tests for `getProfileUrl`, `getWebViewUrl`, and `getDeepLinkUrl` covering both valid and invalid/null cases
- Add `vitest` devDependency and `"test": "vitest run"` script to `packages/shared/package.json`

Closes #9
Closes #10

## Test plan

- [ ] `isSupportedPlatform('github')` → `true`
- [ ] `isSupportedPlatform('linkedin')` → `true`
- [ ] `isSupportedPlatform('myspace')` → `false`
- [ ] `isSupportedPlatform('')` → `false`
- [ ] `isSupportedPlatform('GITHUB')` → `false` (case-sensitive)
- [ ] `getProfileUrl('github', 'octocat')` → `'https://github.com/octocat'`
- [ ] `getProfileUrl('linkedin', 'johndoe')` → `'https://www.linkedin.com/in/johndoe'`
- [ ] `getProfileUrl('unknown', 'x')` → `''`
- [ ] `getWebViewUrl('linkedin', 'johndoe')` → `'https://www.linkedin.com/in/johndoe'`
- [ ] `getWebViewUrl('github', 'octocat')` → `null`
- [ ] `getDeepLinkUrl('twitter', 'elonmusk')` → `'twitter://user?screen_name=elonmusk'`
- [ ] `getDeepLinkUrl('github', 'octocat')` → `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)