### PR TITLE
test file : cover unsupported follow platform error

### DIFF
--- a/apps/backend/src/__tests__/follow.test.ts
+++ b/apps/backend/src/__tests__/follow.test.ts
@@ -1,0 +1,57 @@
+import Fastify from 'fastify';
+import { describe, expect, it, vi } from 'vitest';
+
+import { followRoutes } from '../routes/follow.js';
+
+vi.mock('../utils/encryption.js', () => ({
+  decrypt: vi.fn(() => 'fake-access-token'),
+}));
+
+describe('POST /api/follow/:platform/:targetUsername', () => {
+  it('returns 400 when API follow is not supported for the platform', async () => {
+    const app = Fastify({ logger: false });
+
+    const findUnique = vi.fn().mockResolvedValue({
+      id: 'token-1',
+      userId: 'user-1',
+      platform: 'unknown',
+      accessToken: 'encrypted-token',
+    });
+
+    app.decorate('prisma', {
+      oAuthToken: {
+        findUnique,
+      },
+      followLog: {
+        create: vi.fn(),
+      },
+    }as any);
+
+    app.decorate('authenticate', async (request: any) => {
+      request.user = { id: 'user-1' };
+    });
+
+    await app.register(followRoutes, { prefix: '/api/follow' });
+    await app.ready();
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/follow/unknown/targetUser',
+    });
+
+    const body = response.json();
+
+    expect(response.statusCode).toBe(400);
+    expect(body.error).toContain('API follow not supported');
+    expect(findUnique).toHaveBeenCalledWith({
+      where: {
+        userId_platform: {
+          userId: 'user-1',
+          platform: 'unknown',
+        },
+      },
+    });
+
+    await app.close();
+  });
+});


### PR DESCRIPTION
## Summary

Added a backend Vitest test for the follow route to verify unsupported API-follow platforms return a `400` response with the expected error message.

Closes #6

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] UI / Design change
- [x] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- Added `apps/backend/src/__tests__/follow.test.ts`.
- Added an auth stub for the follow route test.
- Stubbed Prisma and encryption so `POST /api/follow/unknown/targetUser` reaches the unsupported platform branch.

---

## How to Test

1. Run backend tests:
   ```bash
   pnpm --filter @devcard/backend test

---

## Checklist

- [ ] My code follows the project's coding style (pnpm -r run lint passes).
- [ ✔️] TypeScript compiles without errors (pnpm -r run typecheck).
- [ ✔️] I have added or updated tests for the changes I made.
- [ ] All tests pass locally (pnpm -r run test).
- [ ] I have updated documentation where necessary.
- [✔️ ] No new console.log or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description.

---
<img width="455" height="211" alt="Screenshot 2026-05-15 150010" src="https://github.com/user-attachments/assets/2a0cdd7c-81f8-4761-9f7a-3a696be94238" />


##Additional Context

pnpm --filter @devcard/backend test passes locally.

pnpm -r run lint currently fails before reaching this change because eslint is not available in the workspace.

pnpm -r run test currently fails in apps/mobile because Jest cannot parse React Native ESM imports (SyntaxError: Cannot use import statement outside a module). The backend test suite for this change passes.
```