### PR TITLE
docs: add Discord community invitation link to README and CONTRIBUTIN…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,12 @@
 # Contributing to DevCard
 
-Thank you for your interest in contributing to DevCard! This guide will help you get started.
+<p align="center">
+  <a href="https://discord.gg/QueQN83wn">
+    <img src="https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white&style=flat-square" alt="Discord Server" />
+  </a>
+</p>
+
+**Join the community** — ask questions, get help, discuss ideas, and meet other contributors on our [Discord server](https://discord.gg/QueQN83wn).
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
     <a href="https://github.com/Dev-Card/DevCard">
       <img src="https://img.shields.io/badge/GitHub-Dev--Card%2FDevCard-blue?logo=github&style=flat-square" alt="GitHub Repo" />
     </a>
+    <a href="https://discord.gg/QueQN83wn">
+      <img src="https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white&style=flat-square" alt="Discord Server" />
+    </a>
   </p>
 </p>
 


### PR DESCRIPTION
## Summary
Added Discord invitation link (`https://discord.gg/QueQN83wn`) to make the community easily accessible.

- Placed Discord badge next to GitHub badge in `README.md`
- Added Discord badge at the top of `CONTRIBUTING.md`

Closes #130

## Type of Change
- [x] Documentation

## What Changed
- `README.md`
- `CONTRIBUTING.md`