### PR TITLE
implement QR session chaching using remote directory server(Redis)

### DIFF
--- a/apps/backend/src/__tests__/app.test.ts
+++ b/apps/backend/src/__tests__/app.test.ts
@@ -1,7 +1,8 @@
-process.env.NODE_ENV = 'test';
-
 import { describe, it, expect } from 'vitest';
+
 import { buildApp } from '../app';
+
+process.env.NODE_ENV = 'test';
 
 describe('GET /health', () => {
   it('should return status ok', async () => {

--- a/apps/backend/src/__tests__/cards.test.ts
+++ b/apps/backend/src/__tests__/cards.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
 import Fastify from 'fastify';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
 import { cardRoutes } from '../routes/cards.js';
+
 import type { PrismaClient } from '@prisma/client';
 
 const mockPrisma = {

--- a/apps/backend/src/__tests__/event.test.ts
+++ b/apps/backend/src/__tests__/event.test.ts
@@ -1,7 +1,9 @@
+import Fastify, { type FastifyInstance } from 'fastify';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import Fastify, { FastifyInstance } from 'fastify';
-import { PrismaClient } from '@prisma/client';
+
 import { eventRoutes } from '../routes/event';
+
+import type { PrismaClient } from '@prisma/client';
 
 // ─── Shared mock data ────────────────────────────────────────────────────────
 
@@ -64,7 +66,7 @@ const prismaMock = {
 //
 // This mirrors the real app setup without touching a real DB or real JWT keys.
 
-let mockJwtVerify = vi.fn();
+const mockJwtVerify = vi.fn();
 
 async function buildApp(): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });

--- a/apps/backend/src/__tests__/profiles.test.ts
+++ b/apps/backend/src/__tests__/profiles.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Prisma } from '@prisma/client';
 import Fastify from 'fastify';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
 import { profileRoutes } from '../routes/profiles.js';
+
 import type { PrismaClient } from '@prisma/client';
 
 const mockUser = {
@@ -20,17 +23,22 @@ const mockUser = {
   providerId: 'gh-123',
 };
 
-const mockPrisma: Pick<PrismaClient, 'user'> = {
+const mockPrisma = {
   user: {
     findUnique: vi.fn(),
     findFirst: vi.fn(),
     update: vi.fn(),
-  } as unknown as PrismaClient['user'],
+  },
+};
+
+const mockRedis = {
+  del: vi.fn(),
 };
 
 async function buildApp() {
   const app = Fastify();
   app.decorate('prisma', mockPrisma as unknown as PrismaClient);
+  app.decorate('redis', mockRedis as any);
   app.decorate('authenticate', async (request: any) => {
     request.user = { id: 'user-123' };
   });
@@ -68,6 +76,7 @@ describe('PUT /api/profiles/me', () => {
 
   it('should update profile and return updated data', async () => {
     mockPrisma.user.findFirst.mockResolvedValue(null);
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
     mockPrisma.user.update.mockResolvedValue({ ...mockUser, displayName: 'Updated Name' });
     const app = await buildApp();
     const res = await app.inject({
@@ -77,6 +86,22 @@ describe('PUT /api/profiles/me', () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().displayName).toBe('Updated Name');
+  });
+
+  it('should invalidate public profile cache after update', async () => {
+    mockPrisma.user.findFirst.mockResolvedValue(null);
+    mockPrisma.user.findUnique.mockResolvedValue({ username: mockUser.username });
+    mockPrisma.user.update.mockResolvedValue({ ...mockUser, username: 'newuser' });
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/profiles/me',
+      payload: { username: 'newuser' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockRedis.del).toHaveBeenCalledWith('profile:testuser', 'profile:newuser');
   });
 
   it('should return 400 for invalid accentColor', async () => {
@@ -103,10 +128,12 @@ describe('PUT /api/profiles/me', () => {
   });
 
   it('should return 409 when a concurrent request wins the unique constraint race (P2002)', async () => {
-    // Both requests pass the findFirst check; the DB unique constraint fires on
-    // the losing write — Prisma raises P2002.
     mockPrisma.user.findFirst.mockResolvedValue(null);
-    const p2002 = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
+    mockPrisma.user.findUnique.mockResolvedValue({ username: mockUser.username });
+    const p2002 = new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+      code: 'P2002',
+      clientVersion: 'test',
+    });
     mockPrisma.user.update.mockRejectedValue(p2002);
 
     const app = await buildApp();
@@ -122,6 +149,7 @@ describe('PUT /api/profiles/me', () => {
 
   it('should return 500 for unexpected database errors during update', async () => {
     mockPrisma.user.findFirst.mockResolvedValue(null);
+    mockPrisma.user.findUnique.mockResolvedValue({ username: mockUser.username });
     mockPrisma.user.update.mockRejectedValue(new Error('Connection refused'));
 
     const app = await buildApp();
@@ -136,6 +164,7 @@ describe('PUT /api/profiles/me', () => {
   });
 
   it('should not call findFirst when no username is provided in the update', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({ username: mockUser.username });
     mockPrisma.user.update.mockResolvedValue({ ...mockUser, displayName: 'New Name' });
     const app = await buildApp();
     const res = await app.inject({

--- a/apps/backend/src/__tests__/public.test.ts
+++ b/apps/backend/src/__tests__/public.test.ts
@@ -1,69 +1,153 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import jwt from '@fastify/jwt';
 import Fastify from 'fastify';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
 import { publicRoutes } from '../routes/public.js';
+import { generateQRBuffer, generateQRSvg } from '../utils/qr.js';
+
 import type { PrismaClient } from '@prisma/client';
 
-// ── Mock QR utilities ─────────────────────────────────────────────────────────
-// Prevents real QR rasterisation (and any native canvas/image deps) from running
-// during unit tests.  The stubs return minimal valid values that satisfy the
-// Content-Type assertions below.
+
 vi.mock('../utils/qr.js', () => ({
   generateQRBuffer: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
   generateQRSvg: vi.fn().mockResolvedValue('<svg>fake</svg>'),
 }));
 
-import { generateQRBuffer, generateQRSvg } from '../utils/qr.js';
-
 const mockUser = {
   id: 'user-123',
   username: 'testuser',
   displayName: 'Test User',
-  bio: null,
+  bio: 'Building things',
   pronouns: null,
-  role: null,
-  company: null,
+  role: 'Engineer',
+  company: 'DevCard',
   avatarUrl: null,
   accentColor: '#ffffff',
-  platformLinks: [],
+  platformLinks: [
+    {
+      id: 'link-1',
+      platform: 'github',
+      username: 'testuser',
+      url: 'https://github.com/testuser',
+      displayOrder: 0,
+    },
+  ],
+};
+
+const redisStore = new Map<string, string>();
+
+const mockRedis = {
+  get: vi.fn((key: string) => Promise.resolve(redisStore.get(key) ?? null)),
+  setex: vi.fn((key: string, _ttl: number, value: string) => {
+    redisStore.set(key, value);
+    return Promise.resolve('OK');
+  }),
+  del: vi.fn((...keys: string[]) => {
+    keys.forEach((key) => redisStore.delete(key));
+    return Promise.resolve(keys.length);
+  }),
 };
 
 const mockPrisma = {
   user: {
     findUnique: vi.fn(),
   },
-  platformLink: {} as any,
   cardView: {
-    create: vi.fn().mockReturnValue({ catch: vi.fn() }),
+    create: vi.fn(() => Promise.resolve({ id: 'view-1' })),
   },
   followLog: {
     findMany: vi.fn().mockResolvedValue([]),
   },
-  card: {} as any,
+  card: {} as PrismaClient['card'],
 };
 
 async function buildApp() {
   const app = Fastify();
+  await app.register(jwt, { secret: 'test-secret' });
   app.decorate('prisma', mockPrisma as unknown as PrismaClient);
-  // Soft auth: jwtVerify rejects by default (unauthenticated visitor)
-  app.decorateRequest('jwtVerify', async function () {
-    throw new Error('no token');
-  });
+  app.decorate('redis', mockRedis as any);
   app.register(publicRoutes, { prefix: '/api/public' });
   await app.ready();
   return app;
 }
 
-// ─── QR size validation ───────────────────────────────────────────────────────
+describe('GET /api/public/:username', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisStore.clear();
+  });
+
+  it('should cache profile data after a MISS and serve repeat requests as HIT', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+    const app = await buildApp();
+
+    const miss = await app.inject({ method: 'GET', url: '/api/public/testuser' });
+    expect(miss.statusCode).toBe(200);
+    expect(miss.headers['x-cache']).toBe('MISS');
+    expect(miss.headers['cache-control']).toBe('public, max-age=300, stale-while-revalidate=60');
+    expect(miss.json().displayName).toBe('Test User');
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(1);
+    expect(mockRedis.setex).toHaveBeenCalledWith(
+      'profile:testuser',
+      300,
+      expect.any(String),
+    );
+
+    const hit = await app.inject({ method: 'GET', url: '/api/public/testuser' });
+    expect(hit.statusCode).toBe(200);
+    expect(hit.headers['x-cache']).toBe('HIT');
+    expect(hit.json().links[0].platform).toBe('github');
+    expect(mockPrisma.user.findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return 404 without caching when the user is missing', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+    const app = await buildApp();
+
+    const res = await app.inject({ method: 'GET', url: '/api/public/missing' });
+
+    expect(res.statusCode).toBe(404);
+    expect(mockRedis.setex).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/public/:username/qr-session', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    redisStore.clear();
+  });
+
+  it('should return an offline-decodable signed token containing the profile snapshot', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+    const app = await buildApp();
+
+    const res = await app.inject({ method: 'GET', url: '/api/public/testuser/qr-session' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['x-cache']).toBe('MISS');
+    expect(res.json().expiresIn).toBe(600);
+    expect(res.json().tokenType).toBe('JWT');
+
+    const decoded = app.jwt.verify(res.json().token) as {
+      type: string;
+      username: string;
+      profile: { displayName: string };
+      exp: number;
+      iat: number;
+    };
+    expect(decoded.type).toBe('qr-session');
+    expect(decoded.username).toBe('testuser');
+    expect(decoded.profile.displayName).toBe('Test User');
+    expect(decoded.exp - decoded.iat).toBe(600);
+  });
+});
 
 describe('GET /api/public/:username/qr — size validation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Re-attach default mock behaviour cleared by clearAllMocks
     (generateQRBuffer as ReturnType<typeof vi.fn>).mockResolvedValue(Buffer.from('fake-png'));
     (generateQRSvg as ReturnType<typeof vi.fn>).mockResolvedValue('<svg>fake</svg>');
   });
-
-  // ── Reject before DB touch ─────────────────────────────────────────────────
 
   it('rejects size=0 with 400 before any DB query', async () => {
     const app = await buildApp();
@@ -117,10 +201,7 @@ describe('GET /api/public/:username/qr — size validation', () => {
     expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
   });
 
-  it('rejects floating-point size (400.5) with 400', async () => {
-    // parseInt('400.5') === 400, which IS in range — this passes.
-    // Documenting the boundary: fractional strings are truncated, not rejected.
-    // A string like '0.5' parseInt → 0, which is out of range.
+  it('rejects fractional size string (0.5) with 400', async () => {
     const app = await buildApp();
     const res = await app.inject({
       method: 'GET',
@@ -129,8 +210,6 @@ describe('GET /api/public/:username/qr — size validation', () => {
     expect(res.statusCode).toBe(400);
     expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
   });
-
-  // ── Accept valid sizes ─────────────────────────────────────────────────────
 
   it('accepts size=1 (lower bound) and returns PNG', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);
@@ -176,8 +255,6 @@ describe('GET /api/public/:username/qr — size validation', () => {
     );
   });
 
-  // ── Format selection ───────────────────────────────────────────────────────
-
   it('returns SVG when format=svg is requested', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);
     const app = await buildApp();
@@ -193,8 +270,6 @@ describe('GET /api/public/:username/qr — size validation', () => {
     );
   });
 
-  // ── User not found ─────────────────────────────────────────────────────────
-
   it('returns 404 for an unknown username (valid size)', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(null);
     const app = await buildApp();
@@ -205,8 +280,6 @@ describe('GET /api/public/:username/qr — size validation', () => {
     expect(res.statusCode).toBe(404);
     expect(res.json().error).toBe('User not found');
   });
-
-  // ── QR generation error ────────────────────────────────────────────────────
 
   it('returns 500 when QR generation throws', async () => {
     mockPrisma.user.findUnique.mockResolvedValue(mockUser);

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,25 +1,26 @@
-import Fastify from 'fastify';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import cookie from '@fastify/cookie';
 import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
 import jwt from '@fastify/jwt';
-import cookie from '@fastify/cookie';
 import multipart from '@fastify/multipart';
-import fastifyStatic from '@fastify/static';
 import rateLimit from '@fastify/rate-limit';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fastifyStatic from '@fastify/static';
+import Fastify from 'fastify';
 
 import { prismaPlugin } from './plugins/prisma.js';
 import { redisPlugin } from './plugins/redis.js';
-import { authRoutes } from './routes/auth.js';
-import { profileRoutes } from './routes/profiles.js';
-import { cardRoutes } from './routes/cards.js';
-import { publicRoutes } from './routes/public.js';
-import { followRoutes } from './routes/follow.js';
-import { connectRoutes } from './routes/connect.js';
 import { analyticsRoutes } from './routes/analytics.js';
-import { nfcRoutes } from './routes/nfc.js';
+import { authRoutes } from './routes/auth.js';
+import { cardRoutes } from './routes/cards.js';
+import { connectRoutes } from './routes/connect.js';
 import { eventRoutes } from './routes/event.js';
+import { followRoutes } from './routes/follow.js';
+import { nfcRoutes } from './routes/nfc.js';
+import { profileRoutes } from './routes/profiles.js';
+import { publicRoutes } from './routes/public.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -96,6 +97,7 @@ export async function buildApp() {
   await app.register(profileRoutes, { prefix: '/api/profiles' });
   await app.register(cardRoutes, { prefix: '/api/cards' });
   await app.register(publicRoutes, { prefix: '/api/u' });
+  await app.register(publicRoutes, { prefix: '/api/public' });
   await app.register(followRoutes, { prefix: '/api/follow' });
   await app.register(connectRoutes, { prefix: '/api/connect' });
   await app.register(analyticsRoutes, { prefix: '/api/analytics' });

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -1,6 +1,7 @@
-import process from 'node:process';
 import path from 'node:path';
+import process from 'node:process';
 import { fileURLToPath } from 'node:url';
+
 import dotenv from 'dotenv';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/apps/backend/src/plugins/prisma.ts
+++ b/apps/backend/src/plugins/prisma.ts
@@ -1,5 +1,6 @@
-import fp from 'fastify-plugin';
 import { PrismaClient } from '@prisma/client';
+import fp from 'fastify-plugin';
+
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 
 declare module 'fastify' {

--- a/apps/backend/src/plugins/redis.ts
+++ b/apps/backend/src/plugins/redis.ts
@@ -1,5 +1,6 @@
 import fp from 'fastify-plugin';
 import Redis from 'ioredis';
+
 import type { FastifyInstance } from 'fastify';
 
 declare module 'fastify' {

--- a/apps/backend/src/routes/analytics.ts
+++ b/apps/backend/src/routes/analytics.ts
@@ -4,9 +4,9 @@ export async function analyticsRoutes(app: FastifyInstance) {
   
   app.get('/overview', {
     preHandler: [app.authenticate],
-  }, async (request: FastifyRequest, reply: FastifyReply) => {
+  }, async (request: FastifyRequest, _reply: FastifyReply) => {
     const userId = (request.user as any).id;
-    
+
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
@@ -57,7 +57,7 @@ export async function analyticsRoutes(app: FastifyInstance) {
     };
   });
 
-  app.get('/views', {
+  app.get<{ Querystring: { page?: string, cardId?: string } }>('/views', {
     preHandler: [app.authenticate],
   }, async (request: FastifyRequest<{ Querystring: { page?: string, cardId?: string } }>, reply: FastifyReply) => {
     const userId = (request.user as any).id;

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,6 +1,9 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { randomBytes } from 'crypto';
+import { randomBytes } from 'node:crypto';
+
 import { encrypt } from '../utils/encryption.js';
+import { getErrorMessage, getOAuthProviderErrorFields } from '../utils/error.util.js';
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 
 const GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
 const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
@@ -59,8 +62,6 @@ export async function authRoutes(app: FastifyInstance) {
     state,
   });
   const authUrl = `${GITHUB_AUTH_URL}?${params}`;
-  console.log('--- GITHUB OAUTH REDIRECT ---');
-  console.log('URL:', authUrl);
   return reply.redirect(authUrl);
 });
 
@@ -98,7 +99,7 @@ app.get('/github/callback', async (request: FastifyRequest<{ Querystring: OAuthC
       const tokenData = (await tokenRes.json()) as any;
 
       if (tokenData.error) {
-        app.log.error('GitHub token error:', tokenData);
+        app.log.error(getOAuthProviderErrorFields(tokenData), 'GitHub token error');
         return reply.status(400).send({ error: 'Failed to authenticate with GitHub' });
       }
 
@@ -180,8 +181,7 @@ app.get('/github/callback', async (request: FastifyRequest<{ Querystring: OAuthC
 
       return reply.redirect(`${process.env.PUBLIC_APP_URL}/dashboard`);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      app.log.error({ err, message }, 'GitHub auth error');
+      app.log.error(`GitHub auth error: ${getErrorMessage(err)}`);
       return reply.status(500).send({ error: 'Authentication failed' });
     }
   });
@@ -212,8 +212,6 @@ app.get('/github/callback', async (request: FastifyRequest<{ Querystring: OAuthC
     access_type: 'offline',
   });
   const authUrl = `${GOOGLE_AUTH_URL}?${params}`;
-  console.log('--- GOOGLE OAUTH REDIRECT ---');
-  console.log('URL:', authUrl);
   return reply.redirect(authUrl);
 });
 
@@ -247,7 +245,7 @@ app.get('/github/callback', async (request: FastifyRequest<{ Querystring: OAuthC
       const tokenData = (await tokenRes.json()) as any;
 
       if (tokenData.error) {
-        app.log.error('Google token error:', tokenData);
+        app.log.error(getOAuthProviderErrorFields(tokenData), 'Google token error');
         return reply.status(400).send({ error: 'Failed to authenticate with Google' });
       }
 
@@ -301,8 +299,7 @@ app.get('/github/callback', async (request: FastifyRequest<{ Querystring: OAuthC
 
       return reply.redirect(`${process.env.PUBLIC_APP_URL}/dashboard`);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      app.log.error({ err, message }, 'Google auth error');
+      app.log.error(`Google auth error: ${getErrorMessage(err)}`);
       return reply.status(500).send({ error: 'Authentication failed' });
     }
   });

--- a/apps/backend/src/routes/cards.ts
+++ b/apps/backend/src/routes/cards.ts
@@ -1,22 +1,9 @@
-import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import type { Card } from '@devcard/shared';
-
-import { createCardSchema, updateCardSchema } from '../utils/validators.js';
 import { handleDbError } from '../utils/error.util.js';
+import { createCardSchema, updateCardSchema } from '../utils/validators.js';
 
-interface CreateCardBody {
-  title: string;
-  linkIds: string[];
-}
+import type { Card } from '@devcard/shared';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
-interface UpdateCardBody {
-  title?: string;
-  linkIds?: string[];
-}
-
-interface CardParams {
-  id: string;
-}
 
 export async function cardRoutes(app: FastifyInstance): Promise<void> {
   app.addHook('preHandler', app.authenticate);
@@ -52,7 +39,7 @@ export async function cardRoutes(app: FastifyInstance): Promise<void> {
 
   // ─── Create Card ───
 
-  app.post('/', async (request: FastifyRequest<{ Body: CreateCardBody }>, reply: FastifyReply): Promise<Card | void> => {
+  app.post('/', async (request: FastifyRequest, reply: FastifyReply): Promise<Card | void> => {
     const userId = (request.user as { id: string }).id;
     const parsed = createCardSchema.safeParse(request.body);
 
@@ -96,7 +83,7 @@ export async function cardRoutes(app: FastifyInstance): Promise<void> {
 
   // ─── Update Card ───
 
-  app.put('/:id', async (request: FastifyRequest<{ Params: CardParams; Body: UpdateCardBody }>, reply: FastifyReply): Promise<Card | void> => {
+  app.put('/:id', async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply): Promise<Card | void> => {
     const userId = (request.user as { id: string }).id;
     const { id } = request.params;
 
@@ -171,7 +158,7 @@ export async function cardRoutes(app: FastifyInstance): Promise<void> {
 
   // ─── Delete Card ───
 
-  app.delete('/:id', async (request: FastifyRequest<{ Params: CardParams }>, reply: FastifyReply): Promise<void> => {
+  app.delete('/:id', async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply): Promise<void> => {
     const userId = (request.user as { id: string }).id;
     const { id } = request.params;
 
@@ -214,7 +201,7 @@ export async function cardRoutes(app: FastifyInstance): Promise<void> {
 
   // ─── Set Default Card ───
 
-  app.put('/:id/default', async (request: FastifyRequest<{ Params: CardParams }>, reply: FastifyReply): Promise<object | void> => {
+  app.put('/:id/default', async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply): Promise<object | void> => {
     const userId = (request.user as { id: string }).id;
     const { id } = request.params;
 

--- a/apps/backend/src/routes/connect.ts
+++ b/apps/backend/src/routes/connect.ts
@@ -1,6 +1,9 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { randomBytes } from 'crypto';
+import { randomBytes } from 'node:crypto';
+
 import { encrypt } from '../utils/encryption.js';
+import { getErrorMessage, getOAuthProviderErrorFields } from '../utils/error.util.js';
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 
 const GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
 const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
@@ -20,7 +23,7 @@ export async function connectRoutes(app: FastifyInstance) {
 
   app.get('/status', {
     preHandler: [app.authenticate],
-  }, async (request: FastifyRequest, reply: FastifyReply) => {
+  }, async (request: FastifyRequest, _reply: FastifyReply) => {
     const userId = (request.user as any).id;
 
     const tokens = await app.prisma.oAuthToken.findMany({
@@ -107,7 +110,7 @@ app.get('/github', {
       const tokenData = (await tokenRes.json()) as any;
 
       if (tokenData.error) {
-        app.log.error('GitHub connect token error:', tokenData);
+        app.log.error(getOAuthProviderErrorFields(tokenData), 'GitHub connect token error');
         return reply.redirect(`${process.env.PUBLIC_APP_URL}/settings?error=connect_failed`);
       }
 
@@ -142,8 +145,7 @@ app.get('/github', {
       return reply.redirect(`${process.env.PUBLIC_APP_URL}/settings?connected=github`);
 
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      app.log.error({ err, message }, 'GitHub connect error');
+      app.log.error(`GitHub connect error: ${getErrorMessage(err)}`);
       return reply.redirect(`${process.env.PUBLIC_APP_URL}/settings?error=server_error`);
     }
   });
@@ -151,7 +153,7 @@ app.get('/github', {
 
   // ─── Disconnect ───
 
-  app.delete('/:platform', {
+  app.delete<{ Params: { platform: string } }>('/:platform', {
     preHandler: [app.authenticate],
   }, async (request: FastifyRequest<{ Params: { platform: string } }>, reply: FastifyReply) => {
     const userId = (request.user as any).id;
@@ -172,7 +174,7 @@ app.get('/github', {
         },
       });
       return { success: true };
-    } catch (err) {
+    } catch (_err) {
       return reply.status(404).send({ error: 'Connection not found' });
     }
   });

--- a/apps/backend/src/routes/event.ts
+++ b/apps/backend/src/routes/event.ts
@@ -1,6 +1,7 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { createEventSchema, joinEventSchema} from '../validations/event.validation';
-import { Prisma } from '@prisma/client';
+
+import type { Prisma } from '@prisma/client';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 
 type EventDetails = {
     id: string; 
@@ -38,6 +39,9 @@ type PaginatedAttendeesResponse = {
 
 type EventWithAttendees = Prisma.EventGetPayload<{
   include: {
+    _count: {
+      select: { attendees: true };
+    };
     attendees: {
       include: {
         user: {
@@ -81,7 +85,7 @@ export async function eventRoutes(app:FastifyInstance) {
         
         const {name, description, startDate, endDate, isPublic ,location} = parsed.data
 
-        let cleanSlug = name.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^a-z0-9-]+/g, '').replace(/-+/g, '-').replace(/^-+|-+$/g, '')
+        const cleanSlug = name.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^a-z0-9-]+/g, '').replace(/-+/g, '-').replace(/^-+|-+$/g, '')
         let finalSlug = cleanSlug; 
 
         while(true){
@@ -90,7 +94,7 @@ export async function eventRoutes(app:FastifyInstance) {
             if(!existing){
                 break; 
             }
-            const randomSuffix  = Math.random().toString(36).substring(2,6); 
+            const randomSuffix  = Math.random().toString(36).slice(2,6); 
             finalSlug = `${cleanSlug}-${randomSuffix}`
         }
 
@@ -103,7 +107,7 @@ export async function eventRoutes(app:FastifyInstance) {
                     name, 
                     description, 
                     slug: finalSlug, 
-                    location: location,
+                    location,
                     startDate: startDateObj, 
                     endDate: endDateObj, 
                     isPublic: isPublic ?? true, 
@@ -178,7 +182,7 @@ export async function eventRoutes(app:FastifyInstance) {
             await app.prisma.eventAttendee.create({
                 data: {
                     eventId: event.id, 
-                    userId: userId, 
+                    userId, 
                     joinedAt: new Date()
                 }
             })
@@ -218,7 +222,7 @@ export async function eventRoutes(app:FastifyInstance) {
             await app.prisma.eventAttendee.delete({
                 where: {
                     userId_eventId: {
-                        userId: userId, 
+                        userId, 
                         eventId: event.id
                     }
                 }
@@ -289,7 +293,7 @@ export async function eventRoutes(app:FastifyInstance) {
             pagination: {
                 page, 
                 limit, 
-                total : event._count.attendees,
+                total: event._count?.attendees ?? event.attendees.length,
             }
         }
 

--- a/apps/backend/src/routes/follow.ts
+++ b/apps/backend/src/routes/follow.ts
@@ -1,22 +1,21 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { decrypt } from '../utils/encryption.js';
-import { getErrorMessage } from '../utils/error.util.js';
 import { getPlatform, getProfileUrl, getWebViewUrl } from '@devcard/shared';
+
+import { decrypt } from '../utils/encryption.js';
+import { getErrorMessage, logBackgroundError } from '../utils/error.util.js';
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
 
 export async function followRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate);
 
-  // ─── Follow via API (Layer 1) ───
-  // Currently supports: GitHub
-
   app.post('/:platform/:targetUsername', async (
     request: FastifyRequest<{ Params: { platform: string; targetUsername: string } }>,
-    reply: FastifyReply
+    reply: FastifyReply,
   ) => {
-    const userId = (request.user as any).id;
+    const userId = (request.user as { id: string }).id;
     const { platform, targetUsername } = request.params;
 
-    // Use WebView follow strategy if configured for the platform (e.g. LinkedIn, Twitter/X)
     const platformDef = getPlatform(platform);
     if (platformDef?.followStrategy === 'webview') {
       const url = getWebViewUrl(platform, targetUsername) || getProfileUrl(platform, targetUsername);
@@ -26,7 +25,6 @@ export async function followRoutes(app: FastifyInstance) {
       });
     }
 
-    // Get stored OAuth token for this platform
     const oauthToken = await app.prisma.oAuthToken.findUnique({
       where: {
         userId_platform: { userId, platform },
@@ -40,7 +38,6 @@ export async function followRoutes(app: FastifyInstance) {
       });
     }
 
-    // Decrypt the stored token
     const accessToken = decrypt(oauthToken.accessToken);
 
     try {
@@ -58,32 +55,35 @@ export async function followRoutes(app: FastifyInstance) {
           });
       }
 
-      // Log only genuine successes — not based on reply.statusCode default
       if (succeeded) {
-        app.prisma.followLog.create({
+        app.prisma.followLog
+          .create({
+            data: {
+              followerId: userId,
+              targetUsername,
+              platform,
+              status: 'success',
+              layer: 'api',
+            },
+          })
+          .catch((err: unknown) => logBackgroundError(app.log, err, 'Failed to log follow'));
+      }
+
+      return result.response;
+    } catch (err: unknown) {
+      app.log.error(`Follow error for ${platform}: ${getErrorMessage(err)}`);
+
+      app.prisma.followLog
+        .create({
           data: {
             followerId: userId,
             targetUsername,
             platform,
-            status: 'success',
+            status: 'error',
             layer: 'api',
           },
-        }).catch((err: unknown) => app.log.error(`Failed to log follow: ${getErrorMessage(err)}`));
-      }
-
-      return result.response;
-    } catch (err: unknown) { 
-      app.log.error(`Follow error for ${platform}: ${getErrorMessage(err)}`);
-      
-      app.prisma.followLog.create({
-        data: {
-          followerId: userId,
-          targetUsername,
-          platform,
-          status: 'error',
-          layer: 'api',
-        },
-      }).catch((e: unknown) => app.log.error(`Failed to log follow error: ${getErrorMessage(e)}`));
+        })
+        .catch((logErr: unknown) => logBackgroundError(app.log, logErr, 'Failed to log follow error'));
 
       return reply.status(500).send({
         error: 'Follow action failed',
@@ -92,15 +92,14 @@ export async function followRoutes(app: FastifyInstance) {
     }
   });
 
-  // Log follow/connect event for Layer 2/3/4 strategies
   app.post('/:platform/:targetUsername/log', async (
     request: FastifyRequest<{
       Params: { platform: string; targetUsername: string };
       Body: { status?: string; layer?: string };
     }>,
-    reply: FastifyReply
+    reply: FastifyReply,
   ) => {
-    const userId = (request.user as any).id;
+    const userId = (request.user as { id: string }).id;
     const { platform, targetUsername } = request.params;
     const { status = 'success', layer = 'webview' } = request.body || {};
 
@@ -115,18 +114,17 @@ export async function followRoutes(app: FastifyInstance) {
         },
       });
       return reply.send({ status: 'success', logId: log.id });
-    } catch (err: any) {
-      app.log.error('Failed to log follow:', err);
+    } catch (err: unknown) {
+      app.log.error(`Failed to log follow event: ${getErrorMessage(err)}`);
       return reply.status(500).send({ error: 'Failed to log follow event' });
     }
   });
 
-  // ─── Clear follow log (reset Done state) ───
   app.delete('/:platform/:targetUsername/log', async (
     request: FastifyRequest<{ Params: { platform: string; targetUsername: string } }>,
-    reply: FastifyReply
+    reply: FastifyReply,
   ) => {
-    const userId = (request.user as any).id;
+    const userId = (request.user as { id: string }).id;
     const { platform, targetUsername } = request.params;
 
     await app.prisma.followLog.deleteMany({
@@ -141,12 +139,10 @@ export async function followRoutes(app: FastifyInstance) {
   });
 }
 
-// ─── GitHub Follow (Layer 1) ───
-
 async function followGitHub(
   accessToken: string,
   targetUsername: string,
-  reply: FastifyReply
+  reply: FastifyReply,
 ): Promise<{ success: boolean; response: FastifyReply }> {
   const response = await fetch(`https://api.github.com/user/following/${targetUsername}`, {
     method: 'PUT',

--- a/apps/backend/src/routes/nfc.ts
+++ b/apps/backend/src/routes/nfc.ts
@@ -1,5 +1,6 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 
 type NfcPayloadResponse = {
   type: 'URI';

--- a/apps/backend/src/routes/profiles.ts
+++ b/apps/backend/src/routes/profiles.ts
@@ -1,10 +1,14 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { getProfileUrl } from '@devcard/shared';
+import { Prisma } from '@prisma/client';
+
+import { getErrorMessage } from '../utils/error.util.js';
 import {
   updateProfileSchema,
   createLinkSchema,
   reorderLinksSchema,
 } from '../utils/validators.js';
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 
 // ── Response types ────────────────────────────────────────────────────────────
 // Declared explicitly so the API contract is visible without tracing through
@@ -50,7 +54,7 @@ export async function profileRoutes(app: FastifyInstance) {
       return reply.status(404).send({ error: 'User not found' });
     }
 
-    const { provider, providerId, ...profileData } = user;
+    const { provider: _provider, providerId: _providerId, ...profileData } = user;
     return {
       ...profileData,
       defaultCardId: user.cards[0]?.id || null,
@@ -84,8 +88,17 @@ export async function profileRoutes(app: FastifyInstance) {
       }
     }
 
+    const current = await app.prisma.user.findUnique({
+      where: { id: userId },
+      select: { username: true },
+    });
+
+    if (!current) {
+      return reply.status(404).send({ error: 'User not found' });
+    }
+
     try {
-      const response: ProfileUpdateResponse = await app.prisma.user.update({
+      const updated: ProfileUpdateResponse = await app.prisma.user.update({
         where: { id: userId },
         data: parsed.data,
         select: {
@@ -102,16 +115,26 @@ export async function profileRoutes(app: FastifyInstance) {
         },
       });
 
-      return response;
-    } catch (err: any) {
-      // Unique constraint violation — two concurrent requests raced through the
-      // findFirst check above and both attempted the write. The DB constraint
-      // fires on the losing request; surface it as a deterministic 409 rather
-      // than leaking a raw Prisma error as a 500.
-      if (err?.code === 'P2002') {
+      const cacheKeys = new Set([
+        `profile:${current.username}`,
+        ...(updated.username !== current.username ? [`profile:${updated.username}`] : []),
+      ]);
+
+      try {
+        await app.redis.del(...cacheKeys);
+      } catch (err) {
+        app.log.warn(
+          { err: getErrorMessage(err), userId },
+          'Failed to invalidate public profile cache',
+        );
+      }
+
+      return updated;
+    } catch (err: unknown) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
         return reply.status(409).send({ error: 'Username already taken' });
       }
-      app.log.error({ err }, 'DB error in PUT /profiles/me');
+      app.log.error(`DB error in PUT /profiles/me: ${getErrorMessage(err)}`);
       return reply.status(500).send({ error: 'Internal server error' });
     }
   });

--- a/apps/backend/src/routes/public.ts
+++ b/apps/backend/src/routes/public.ts
@@ -1,199 +1,330 @@
-import type { FastifyContextConfig, FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { getErrorMessage, logBackgroundError } from '../utils/error.util.js';
 import { generateQRBuffer, generateQRSvg } from '../utils/qr.js';
+
 import type { PlatformLink } from '@devcard/shared';
-import { getErrorMessage } from '../utils/error.util.js';
+import type { Prisma } from '@prisma/client';
+import type { FastifyContextConfig, FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
 
 
 // ── QR size bounds ────────────────────────────────────────────────────────────
-// Enforced before any DB query or image allocation.  Values outside this range
-// are rejected with 400 so a single unauthenticated request cannot trigger an
-// unbounded memory allocation in the QR rasteriser.
 const MIN_QR_SIZE = 1;
 const MAX_QR_SIZE = 2048;
+
 type PublicProfileLink = {
   id: string;
   platform: string;
-  username: string; 
-  url: string; 
-  displayOrder: number; 
+  username: string;
+  url: string;
+  displayOrder: number;
   followed?: boolean;
-}
+};
 
-type UsernamePublicProfileResponse =  {
-  username: string; 
+type UsernamePublicProfileResponse = {
+  username: string;
   displayName: string;
-  bio: string | null; 
-  pronouns: string | null; 
-  role: string | null; 
+  bio: string | null;
+  pronouns: string | null;
+  role: string | null;
   company: string | null;
-  avatarUrl: string | null; 
+  avatarUrl: string | null;
   accentColor: string;
-  links: PublicProfileLink[]
-} 
+  links: PublicProfileLink[];
+};
 
 type PublicProfileCardLink = {
   id: string;
   platform: string;
-  username: string; 
-  url: string; 
+  username: string;
+  url: string;
   followed?: boolean;
-}
+};
 
 type CardPublicProfileResponse = {
-  id: string; 
-  title: string; 
+  id: string;
+  title: string;
   owner: {
-    username: string; 
-    displayName: string; 
+    username: string;
+    displayName: string;
     bio: string | null;
     avatarUrl: string | null;
-    accentColor: string; 
-  }; 
-  links: PublicProfileCardLink[]
-}
+    accentColor: string;
+  };
+  links: PublicProfileCardLink[];
+};
 
 type UsernameCardPublicProfileResponse = {
-  title: string; 
+  title: string;
   owner: {
-    username: string; 
+    username: string;
     displayName: string;
-    bio: string | null; 
-    pronouns: string | null; 
-    role: string | null; 
+    bio: string | null;
+    pronouns: string | null;
+    role: string | null;
     company: string | null;
-    avatarUrl: string | null; 
+    avatarUrl: string | null;
     accentColor: string;
-  }; 
-  links: PublicProfileCardLink[]
-}
+  };
+  links: PublicProfileCardLink[];
+};
 
-// Represents a CardLink record with the joined PlatformLink relation
+type CachedPublicProfile = {
+  ownerId: string;
+  profile: UsernamePublicProfileResponse;
+};
+
+type UserWithPlatformLinks = Prisma.UserGetPayload<{
+  include: {
+    platformLinks: {
+      orderBy: { displayOrder: 'asc' };
+    };
+  };
+}>;
+
 interface CardLinkWithPlatform {
   id: string;
   displayOrder: number;
   platformLink: PlatformLink;
 }
 
+const PROFILE_CACHE_TTL_SECONDS = 300;
+const QR_SESSION_TTL_SECONDS = 600;
+const PUBLIC_PROFILE_CACHE_CONTROL = 'public, max-age=300, stale-while-revalidate=60';
+
+function profileCacheKey(username: string) {
+  return `profile:${username}`;
+}
+
+function buildUsernamePublicProfile(user: UserWithPlatformLinks): UsernamePublicProfileResponse {
+  return {
+    username: user.username,
+    displayName: user.displayName,
+    bio: user.bio,
+    pronouns: user.pronouns,
+    role: user.role,
+    company: user.company,
+    avatarUrl: user.avatarUrl,
+    accentColor: user.accentColor,
+    links: user.platformLinks.map((link) => ({
+      id: link.id,
+      platform: link.platform,
+      username: link.username,
+      url: link.url,
+      displayOrder: link.displayOrder,
+    })),
+  };
+}
+
+async function getCachedProfile(app: FastifyInstance, username: string): Promise<CachedPublicProfile | null> {
+  try {
+    const cached = await app.redis.get(profileCacheKey(username));
+    if (!cached) {
+      return null;
+    }
+
+    return JSON.parse(cached) as CachedPublicProfile;
+  } catch (err) {
+    app.log.warn({ err: getErrorMessage(err), username }, 'Failed to read public profile cache');
+    return null;
+  }
+}
+
+async function cacheProfile(app: FastifyInstance, username: string, payload: CachedPublicProfile) {
+  try {
+    await app.redis.setex(profileCacheKey(username), PROFILE_CACHE_TTL_SECONDS, JSON.stringify(payload));
+  } catch (err) {
+    app.log.warn({ err: getErrorMessage(err), username }, 'Failed to write public profile cache');
+  }
+}
+
+async function resolvePublicProfile(app: FastifyInstance, username: string) {
+  const cached = await getCachedProfile(app, username);
+  if (cached) {
+    return { cacheStatus: 'HIT' as const, payload: cached };
+  }
+
+  const user = await app.prisma.user.findUnique({
+    where: { username },
+    include: {
+      platformLinks: {
+        orderBy: { displayOrder: 'asc' },
+      },
+    },
+  });
+
+  if (!user) {
+    return null;
+  }
+
+  const payload: CachedPublicProfile = {
+    ownerId: user.id,
+    profile: buildUsernamePublicProfile(user),
+  };
+
+  await cacheProfile(app, username, payload);
+
+  return { cacheStatus: 'MISS' as const, payload };
+}
+
+async function getViewerId(request: FastifyRequest, ownerId: string): Promise<string | null> {
+  try {
+    if (request.headers.authorization) {
+      const decoded = (await request.jwtVerify()) as { id?: string };
+      if (decoded?.id && decoded.id !== ownerId) {
+        return decoded.id;
+      }
+    }
+  } catch {
+    // Ignored if invalid token
+  }
+
+  return null;
+}
+
+async function enrichProfileWithFollowedLinks(
+  app: FastifyInstance,
+  profile: UsernamePublicProfileResponse,
+  viewerId: string | null,
+): Promise<UsernamePublicProfileResponse> {
+  if (!viewerId || profile.links.length === 0) {
+    return profile;
+  }
+
+  const successfulFollows = await app.prisma.followLog.findMany({
+    where: {
+      followerId: viewerId,
+      status: 'success',
+      OR: profile.links.map((link) => ({
+        platform: link.platform,
+        targetUsername: link.username,
+      })),
+    },
+    select: {
+      platform: true,
+      targetUsername: true,
+    },
+  });
+
+  const followedLinkIds = profile.links
+    .filter((link) =>
+      successfulFollows.some(
+        (f) =>
+          f.platform === link.platform &&
+          f.targetUsername.toLowerCase() === link.username.toLowerCase(),
+      ),
+    )
+    .map((link) => link.id);
+
+  return {
+    ...profile,
+    links: profile.links.map((link) => ({
+      ...link,
+      followed: followedLinkIds.includes(link.id),
+    })),
+  };
+}
+
+function trackProfileView(
+  app: FastifyInstance,
+  request: FastifyRequest<{ Querystring: { source?: string } }>,
+  ownerId: string,
+  viewerId: string | null,
+) {
+  if (!viewerId || viewerId === ownerId) {
+    return;
+  }
+
+  app.prisma.cardView
+    .create({
+      data: {
+        ownerId,
+        cardId: null,
+        viewerId,
+        viewerIp: request.ip || null,
+        viewerAgent: request.headers['user-agent'] || null,
+        source: request.query?.source || 'link',
+      },
+    })
+    .catch((err: unknown) => logBackgroundError(app.log, err, 'Failed to log view'));
+}
 
 export async function publicRoutes(app: FastifyInstance) {
-  // ─── Public Profile ───
   app.get('/:username', {
     config: {
       rateLimit: {
         max: 100,
-        timeWindow: '1 minute'
-      }
-    } as FastifyContextConfig
-  }, async (request: FastifyRequest<{ Params: { username: string }; Querystring: { source?: string } }>, reply: FastifyReply) => {
+        timeWindow: '1 minute',
+      },
+    } as FastifyContextConfig,
+  }, async (
+    request: FastifyRequest<{ Params: { username: string }; Querystring: { source?: string } }>,
+    reply: FastifyReply,
+  ) => {
     const { username } = request.params;
 
-    const user = await app.prisma.user.findUnique({
-      where: { username },
-      include: {
-        platformLinks: {
-          orderBy: { displayOrder: 'asc' },
-        },
-      },
-    });
-
-    if (!user) {
+    const resolved = await resolvePublicProfile(app, username);
+    if (!resolved) {
       return reply.status(404).send({ error: 'User not found' });
     }
 
-    // Try to extract viewer from Authorization header (soft auth)
-    let viewerId: string | null = null;
-    try {
-      if (request.headers.authorization) {
-        const decoded = (await request.jwtVerify()) as { id?: string };
-        viewerId = decoded?.id ?? null;
-      } else {
-        viewerId = null; // Unauthenticated viewer
-      }
-    } catch {
-      // Ignored if invalid token
-    }
+    const viewerId = await getViewerId(request, resolved.payload.ownerId);
+    const profile = await enrichProfileWithFollowedLinks(app, resolved.payload.profile, viewerId);
+    trackProfileView(app, request, resolved.payload.ownerId, viewerId);
 
-    // Don't track if the owner is viewing their own profile
-    if (viewerId && viewerId !== user.id) {
-      // Background view tracking
-      app.prisma.cardView.create({
-        data: {
-          ownerId: user.id,
-          cardId: null, // this is a profile view, not a card view
-          viewerId,
-          viewerIp: request.ip || null,
-          viewerAgent: request.headers['user-agent'] || null,
-          source: request.query?.source || 'link',
-        },
-      }).catch((err: unknown) => app.log.error(`Failed to log view: ${getErrorMessage(err)}`));
-    }
-
-    // Fetch viewer's successful follow logs for this profile's links
-    let followedLinkIds: string[] = [];
-    if (viewerId && user.platformLinks.length > 0) {
-      const successfulFollows = await app.prisma.followLog.findMany({
-        where: {
-          followerId: viewerId,
-          status: 'success',
-          OR: user.platformLinks.map((link: PlatformLink) => ({
-            platform: link.platform,
-            targetUsername: link.username,
-          })),
-        },
-        select: {
-          platform: true,
-          targetUsername: true,
-        },
-      });
-
-      followedLinkIds = user.platformLinks
-        .filter((link: PlatformLink) =>
-          successfulFollows.some((f: { platform: string; targetUsername: string }) =>
-            f.platform === link.platform &&
-            f.targetUsername.toLowerCase() === link.username.toLowerCase()
-          )
-        )
-        .map((link: PlatformLink) => link.id);
-    }
-
-    const response: UsernamePublicProfileResponse = {
-      username: user.username,
-      displayName: user.displayName,
-      bio: user.bio,
-      pronouns: user.pronouns,
-      role: user.role,
-      company: user.company,
-      avatarUrl: user.avatarUrl,
-      accentColor: user.accentColor,
-      links: user.platformLinks.map((link: PlatformLink) => ({
-        id: link.id,
-        platform: link.platform,
-        username: link.username,
-        url: link.url,
-        displayOrder: link.displayOrder,
-        followed: followedLinkIds.includes(link.id),
-      })),
-    }
-
-    return response; 
-
+    return reply
+      .header('Cache-Control', PUBLIC_PROFILE_CACHE_CONTROL)
+      .header('X-Cache', resolved.cacheStatus)
+      .send(profile);
   });
 
   /**
-   * GET /api/public/card/:cardId
-   * Returns public data for a shared card via its direct link.
-   * Used for standalone card sharing (minimal owner info).
-  */
-  // ─── Shared Card View (Direct) ───
+   * GET /api/public/:username/qr-session
+   * Offline QR mode: returns a short-lived signed JWT embedding the public profile snapshot.
+   */
+  app.get('/:username/qr-session', async (
+    request: FastifyRequest<{ Params: { username: string } }>,
+    reply: FastifyReply,
+  ) => {
+    const { username } = request.params;
+
+    const resolved = await resolvePublicProfile(app, username);
+    if (!resolved) {
+      return reply.status(404).send({ error: 'User not found' });
+    }
+
+    const issuedAt = Math.floor(Date.now() / 1000);
+    const expiresAt = issuedAt + QR_SESSION_TTL_SECONDS;
+    const token = app.jwt.sign(
+      {
+        type: 'qr-session',
+        username,
+        profile: resolved.payload.profile,
+      },
+      { expiresIn: `${QR_SESSION_TTL_SECONDS}s` },
+    );
+
+    return reply
+      .header('Cache-Control', PUBLIC_PROFILE_CACHE_CONTROL)
+      .header('X-Cache', resolved.cacheStatus)
+      .send({
+        token,
+        tokenType: 'JWT',
+        expiresIn: QR_SESSION_TTL_SECONDS,
+        expiresAt: new Date(expiresAt * 1000).toISOString(),
+      });
+  });
 
   app.get('/card/:cardId', {
     config: {
       rateLimit: {
         max: 100,
-        timeWindow: '1 minute'
-      }
-    } as FastifyContextConfig
-  }, async (request: FastifyRequest<{ Params: { cardId: string } }>, reply: FastifyReply) => {
+        timeWindow: '1 minute',
+      },
+    } as FastifyContextConfig,
+  }, async (
+    request: FastifyRequest<{ Params: { cardId: string } }>,
+    reply: FastifyReply,
+  ) => {
     const { cardId } = request.params;
 
     const card = await app.prisma.card.findUnique({
@@ -227,26 +358,22 @@ export async function publicRoutes(app: FastifyInstance) {
         username: cl.platformLink.username,
         url: cl.platformLink.url,
       })),
-    }
+    };
 
-    return response; 
-
+    return response;
   });
 
-  // ─── Public Card View ───
   app.get('/:username/card/:cardId', {
     config: {
       rateLimit: {
         max: 100,
-        timeWindow: '1 minute'
-      }
-    } as FastifyContextConfig
-  }, async (request: FastifyRequest<{ Params: { username: string; cardId: string }; Querystring: { source?: string } }>, reply: FastifyReply) => {
-    /**
-     * GET /api/public/:username/card/:cardId
-     * Returns full owner profile + specific card data.
-     * Used when viewing a card through username + cardId (e.g. QR code scans).
-    */
+        timeWindow: '1 minute',
+      },
+    } as FastifyContextConfig,
+  }, async (
+    request: FastifyRequest<{ Params: { username: string; cardId: string }; Querystring: { source?: string } }>,
+    reply: FastifyReply,
+  ) => {
     const { username, cardId } = request.params;
 
     const user = await app.prisma.user.findUnique({
@@ -271,29 +398,22 @@ export async function publicRoutes(app: FastifyInstance) {
       return reply.status(404).send({ error: 'Card not found' });
     }
 
-    let viewerId: string | null = null;
-    try {
-      if (request.headers.authorization) {
-        const decoded = (await request.jwtVerify()) as { id?: string };
-        viewerId = decoded?.id ?? null;
-      }
-    } catch {
-      // Ignored if invalid token
-    }
+    const viewerId = await getViewerId(request, user.id);
 
-    if (viewerId && viewerId !== user.id) {
-      app.prisma.cardView.create({
-        data: {
-          ownerId: user.id,
-          cardId: card.id,
-          viewerId,
-          viewerIp: request.ip || null,
-          viewerAgent: request.headers['user-agent'] || null,
-          source: request.query?.source || 'qr',
-        },
-      }).catch((err: unknown) => app.log.error(`Failed to log view: ${getErrorMessage(err)}`));
+    if (viewerId) {
+      app.prisma.cardView
+        .create({
+          data: {
+            ownerId: user.id,
+            cardId: card.id,
+            viewerId,
+            viewerIp: request.ip || null,
+            viewerAgent: request.headers['user-agent'] || null,
+            source: request.query?.source || 'qr',
+          },
+        })
+        .catch((err: unknown) => logBackgroundError(app.log, err, 'Failed to log card view'));
     }
-
 
     const response: UsernameCardPublicProfileResponse = {
       title: card.title,
@@ -314,30 +434,28 @@ export async function publicRoutes(app: FastifyInstance) {
         url: cl.platformLink.url,
         displayOrder: cl.displayOrder,
       })),
-    }
-    return response; 
-  });
+    };
 
-  // ─── QR Code Generation ───
+    return response;
+  });
 
   app.get('/:username/qr', {
     config: {
       rateLimit: {
-        max: 50, // Lower limit for QR generation as it's more resource intensive
-        timeWindow: '1 minute'
-      }
-    } as FastifyContextConfig
-  }, async (request: FastifyRequest<{
-    Params: { username: string };
-    Querystring: { format?: string; size?: string };
-  }>, reply: FastifyReply) => {
+        max: 50,
+        timeWindow: '1 minute',
+      },
+    } as FastifyContextConfig,
+  }, async (
+    request: FastifyRequest<{
+      Params: { username: string };
+      Querystring: { format?: string; size?: string };
+    }>,
+    reply: FastifyReply,
+  ) => {
     const { username } = request.params;
-    const format = (request.query as any).format || 'png';
-
-    // Parse and validate size before touching the DB or allocating any buffers.
-    // parseInt safely handles non-numeric strings (returns NaN) and ignores any
-    // trailing fractional part, so '400.9' → 400 which is within bounds.
-    const rawSize = (request.query as any).size;
+    const format = request.query.format || 'png';
+    const rawSize = request.query.size;
     const size = rawSize !== undefined ? parseInt(rawSize, 10) : 400;
 
     if (!Number.isInteger(size) || size < MIN_QR_SIZE || size > MAX_QR_SIZE) {
@@ -346,7 +464,6 @@ export async function publicRoutes(app: FastifyInstance) {
       });
     }
 
-    // Verify user exists
     const user = await app.prisma.user.findUnique({
       where: { username },
     });
@@ -372,7 +489,10 @@ export async function publicRoutes(app: FastifyInstance) {
         .header('Content-Disposition', `inline; filename="devcard-${username}.png"`)
         .send(png);
     } catch (err) {
-      app.log.error({ err, username, size, format }, 'QR generation failed');
+      app.log.error(
+        { err: getErrorMessage(err), username, size, format },
+        'QR generation failed',
+      );
       return reply.status(500).send({ error: 'QR code generation failed' });
     }
   });

--- a/apps/backend/src/utils/encryption.ts
+++ b/apps/backend/src/utils/encryption.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 16;

--- a/apps/backend/src/utils/error.util.ts
+++ b/apps/backend/src/utils/error.util.ts
@@ -1,8 +1,32 @@
-import type { FastifyReply, FastifyRequest } from 'fastify';
 import { Prisma } from '@prisma/client';
+
+import type { FastifyBaseLogger, FastifyReply, FastifyRequest } from 'fastify';
 
 export function getErrorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/** Log a non-fatal background task failure without dumping raw error objects. */
+export function logBackgroundError(
+  log: FastifyBaseLogger,
+  err: unknown,
+  message: string,
+  context?: Record<string, unknown>,
+) {
+  log.error({ ...context, err: getErrorMessage(err) }, message);
+}
+
+/** Safe fields for OAuth provider error responses (never log tokens). */
+export function getOAuthProviderErrorFields(tokenData: {
+  error?: string;
+  error_description?: string;
+}) {
+  return {
+    error: tokenData.error,
+    ...(tokenData.error_description
+      ? { errorDescription: tokenData.error_description }
+      : {}),
+  };
 }
 
 export function handleDbError(error: unknown, request: FastifyRequest, reply: FastifyReply) {

--- a/apps/backend/src/utils/validators.ts
+++ b/apps/backend/src/utils/validators.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
 import { getPlatform } from '@devcard/shared';
+import { z } from 'zod';
 
 export const updateProfileSchema = z.object({
   displayName: z.string().min(1).max(100).optional(),


### PR DESCRIPTION

[PR_DESCRIPTION.md](https://github.com/user-attachments/files/27902946/PR_DESCRIPTION.md)
## Summary

Implements Redis-backed public profile caching and offline QR session tokens for Offline QR Mode. Public profile responses are cached for 5 minutes to reduce PostgreSQL reads on repeat views, profile updates invalidate the cache, and a new QR session endpoint returns a short-lived signed profile snapshot token for offline/native QR flows. Closes #46

---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- Added Redis-backed public profile caching in `apps/backend/src/routes/public.ts`, storing successful profile fetches under `profile:<username>` with a 5-minute TTL.
- Added `X-Cache` response headers for public profile responses, returning `MISS` on DB-backed responses and `HIT` on Redis-backed responses.
- Added `Cache-Control: public, max-age=300, stale-while-revalidate=60` to public profile and QR session responses.
- Added `GET /api/public/:username/qr-session`, returning a signed 10-minute JWT containing the public profile snapshot for offline QR use cases.
- Added cache invalidation in `PUT /api/profiles/me`, deleting cached profile keys when a user updates their profile or changes username.
- Registered public routes under `/api/public` while preserving the existing `/api/u` route prefix.
- Added tests for cache HIT/MISS behavior, reduced DB calls on repeat requests, cache invalidation, and QR session token contents.
- Added backend TypeScript fixes for Fastify decorator typing and logger call typing so the backend build passes.

---

## How to Test

1. Run backend tests:

```bash
pnpm --filter @devcard/backend test
```

2. Run backend TypeScript build:

```bash
pnpm --filter @devcard/backend build
```

3. Manually verify Redis cache behavior with seeded data:

```bash
curl -i http://localhost:3000/api/public/devcard-demo
curl -i http://localhost:3000/api/public/devcard-demo
```

Expected:
- First request returns `X-Cache: MISS`
- Second request returns `X-Cache: HIT`

4. Verify QR session token response:

```bash
curl http://localhost:3000/api/public/devcard-demo/qr-session
```

Expected:
- Response includes `token`, `tokenType: JWT`, `expiresIn: 600`, and `expiresAt`.

---

## Checklist

- [ ] My code follows the project's coding style (`pnpm -r run lint` passes).
- [x] TypeScript compiles without errors (`pnpm --filter @devcard/backend build` passes).
- [x] I have added or updated tests for the changes I made.
- [x] Backend tests pass locally (`pnpm --filter @devcard/backend test`).
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [x] Breaking changes are documented in this PR description.

---

## Screenshots / Recordings

Not applicable. This is a backend API change.

---

## Additional Context

The Redis plugin was already present and registered in the Fastify app. This PR builds on that plugin and adds the caching, invalidation, headers, QR session token endpoint, and tests required for Offline QR Mode.
```
