### PR TITLE
fix: use randomBytes() instead of Math.random() for OAuth state gener…

### DIFF
--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-
+import { randomBytes } from 'crypto';
 const GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
 const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 const GITHUB_USER_URL = 'https://api.github.com/user';
@@ -287,5 +287,5 @@ export async function authRoutes(app: FastifyInstance) {
 }
 
 function generateState(): string {
-  return Math.random().toString(36).substring(2, 15);
+  return randomBytes(32).toString('hex');
 }

--- a/apps/backend/src/routes/connect.ts
+++ b/apps/backend/src/routes/connect.ts
@@ -170,5 +170,5 @@ function parseGoogleState(state: string): ParsedOAuthState | null {
 }
 
 function generateState(): string {
-  return Math.random().toString(36).substring(2, 15);
+  return randomBytes(32).toString('hex');
 }


### PR DESCRIPTION
## Summary

Fixes the `generateState()` function in `auth.ts` and `connect.ts` by replacing the insecure `Math.random()` implementation with a cryptographically secure random value for the OAuth `state` parameter.

## Problem

The previous implementation used:

```ts
function generateState(): string {
  return Math.random().toString(36).substring(2, 15);
}
```

`Math.random()` is not cryptographically secure and can produce predictable values. Since the OAuth `state` parameter is used to prevent CSRF attacks, predictable state values weaken this protection.

## Fix

Replaced the implementation with `randomBytes()` from Node.js' built-in `crypto` module:

```ts
import { randomBytes } from 'crypto';

function generateState(): string {
  return randomBytes(32).toString('hex');
}
```

This generates 256 bits of cryptographically secure randomness, making the OAuth `state` parameter unpredictable and resistant to CSRF attacks.

## Files Changed

* `apps/backend/src/routes/auth.ts`
* `apps/backend/src/routes/connect.ts`

## Related

Closes #123
