### PR TITLE
fix: pass JWT via URL fragment instead of query param in mobile redirect

### DIFF
--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -117,10 +117,10 @@ export async function authRoutes(app: FastifyInstance) {
         { expiresIn: '30d' }
       );
 
-      // For mobile app: redirect with token as query param
+      // For mobile app: redirect with token as URL fragment (not sent to servers, keeps token out of logs)
       const mobileRedirect = process.env.MOBILE_REDIRECT_URI;
       if (request.query.state?.startsWith('mobile_')) {
-        return reply.redirect(`${mobileRedirect}?token=${token}`);
+        return reply.redirect(`${mobileRedirect}#token=${token}`);
       }
 
       // For web: set cookie and redirect
@@ -222,7 +222,7 @@ export async function authRoutes(app: FastifyInstance) {
 
       if (request.query.state?.startsWith('mobile_')) {
         const mobileRedirect = process.env.MOBILE_REDIRECT_URI;
-        return reply.redirect(`${mobileRedirect}?token=${token}`);
+        return reply.redirect(`${mobileRedirect}#token=${token}`);
       }
 
       reply.setCookie('token', token, {


### PR DESCRIPTION
Fixes the mobile OAuth redirect in auth.ts to pass the JWT token via a URL fragment (#) instead of a query parameter (?).
Problem
Both the GitHub and Google OAuth callbacks were redirecting mobile users with the JWT as a plain query parameter:
tsreturn reply.redirect(`${mobileRedirect}?token=${token}`);
This meant the JWT (valid for 30 days) was:

Visible in server access logs
Stored in browser/webview history
Potentially captured by analytics or proxy tools
Exposed to any third-party JavaScript reading location.href

Fix
Changed ? to # so the token is passed as a URL fragment:
tsreturn reply.redirect(`${mobileRedirect}#token=${token}`);
URL fragments are never sent to the server in HTTP requests, so the token won't appear in access logs or be forwarded to proxies.
Files Changed

apps/backend/src/routes/auth.ts

Related
Closes #122