### PR TITLE
fix(auth): validate OAuth state parameter in GitHub and Google callbacks

### DIFF
--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -20,6 +20,15 @@ export async function authRoutes(app: FastifyInstance) {
     const clientState = (request.query as any).state || '';
     const state = clientState ? `${clientState}_${generateState()}` : generateState();
 
+    // Store state in a short-lived cookie so the callback can verify it
+    reply.setCookie('oauth_state', state, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 10 * 60,
+    });
+
     const params = new URLSearchParams({
       client_id: (process.env.GITHUB_CLIENT_ID || '').trim(),
       redirect_uri: redirectUri,
@@ -27,13 +36,20 @@ export async function authRoutes(app: FastifyInstance) {
       state,
     });
     const authUrl = `${GITHUB_AUTH_URL}?${params}`;
-    console.log('--- GITHUB OAUTH REDIRECT ---');
-    console.log('URL:', authUrl);
     return reply.redirect(authUrl);
   });
 
   app.get('/github/callback', async (request: FastifyRequest<{ Querystring: OAuthCallbackQuery }>, reply: FastifyReply) => {
-    const { code } = request.query;
+    const { code, state } = request.query;
+
+    // Validate state to prevent CSRF attacks
+    const storedState = (request.cookies as any).oauth_state;
+    reply.clearCookie('oauth_state', { path: '/' });
+
+    if (!storedState || !state || state !== storedState) {
+      return reply.status(400).send({ error: 'Invalid OAuth state parameter.' });
+    }
+
     if (!code) {
       return reply.status(400).send({ error: 'Missing authorization code' });
     }
@@ -146,6 +162,15 @@ export async function authRoutes(app: FastifyInstance) {
     const clientState = (request.query as any).state || '';
     const state = clientState ? `${clientState}_${generateState()}` : generateState();
 
+    // Store state in a short-lived cookie so the callback can verify it
+    reply.setCookie('oauth_state', state, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 10 * 60,
+    });
+
     const params = new URLSearchParams({
       client_id: (process.env.GOOGLE_CLIENT_ID || '').trim(),
       redirect_uri: redirectUri,
@@ -155,13 +180,20 @@ export async function authRoutes(app: FastifyInstance) {
       access_type: 'offline',
     });
     const authUrl = `${GOOGLE_AUTH_URL}?${params}`;
-    console.log('--- GOOGLE OAUTH REDIRECT ---');
-    console.log('URL:', authUrl);
     return reply.redirect(authUrl);
   });
 
   app.get('/google/callback', async (request: FastifyRequest<{ Querystring: OAuthCallbackQuery }>, reply: FastifyReply) => {
-    const { code } = request.query;
+    const { code, state } = request.query;
+
+    // Validate state to prevent CSRF attacks
+    const storedState = (request.cookies as any).oauth_state;
+    reply.clearCookie('oauth_state', { path: '/' });
+
+    if (!storedState || !state || state !== storedState) {
+      return reply.status(400).send({ error: 'Invalid OAuth state parameter.' });
+    }
+
     if (!code) {
       return reply.status(400).send({ error: 'Missing authorization code' });
     }


### PR DESCRIPTION
Closes #147

## What was wrong

Both `/auth/github` and `/auth/google` generated a `state` parameter and passed it to the provider, but neither callback route validated the returned state against what was originally sent. This made the CSRF protection completely non-functional - a forged callback from any origin would pass straight through to token exchange and account creation/login.

## What changed

- Before redirecting to GitHub or Google, the generated `state` value is stored in a short-lived `httpOnly` cookie (`oauth_state`, max-age 10 minutes).
- On callback, the cookie value is compared against `request.query.state`. If they do not match (or either is missing), the request is rejected with `400`.
- The cookie is cleared immediately after the check regardless of outcome so it cannot be reused.
- Removed `console.log` calls that were printing full OAuth URLs (including client IDs) to stdout.

## Type of change

- [x] Bug fix
- [x] Security fix