### PR TITLE
Fix/idor card link ownership

### DIFF
--- a/apps/backend/src/routes/cards.ts
+++ b/apps/backend/src/routes/cards.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+Dimport type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { createCardSchema, updateCardSchema } from '../utils/validators.js';
 
 export async function cardRoutes(app: FastifyInstance) {
@@ -100,6 +100,14 @@ export async function cardRoutes(app: FastifyInstance) {
     if (parsed.data.linkIds) {
       // Remove existing links
       await app.prisma.cardLink.deleteMany({ where: { cardId: id } });
+
+      // Verify all linkIds belong to the current user — prevents IDOR
+      const validLinks = await app.prisma.platformLink.findMany({
+        where: { id: { in: parsed.data.linkIds }, userId },
+      });
+      if (validLinks.length !== parsed.data.linkIds.length) {
+        return reply.status(403).send({ error: 'One or more links do not belong to you' });
+      }
       // Add new links
       await app.prisma.cardLink.createMany({
         data: parsed.data.linkIds.map((linkId, index) => ({

--- a/packages/shared/src/__tests__/cards.test.ts
+++ b/packages/shared/src/__tests__/cards.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { validateCardPlatforms, diffCardPlatforms } from '../cards';
+
+describe('validateCardPlatforms', () => {
+  it('passes with valid platforms', () => {
+    const result = validateCardPlatforms(['github', 'linkedin']);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('fails with empty array', () => {
+    const result = validateCardPlatforms([]);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('At least one platform is required.');
+  });
+
+  it('fails with unknown platform', () => {
+    const result = validateCardPlatforms(['github', 'myspace']);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('myspace'))).toBe(true);
+  });
+
+  it('fails with duplicate platforms', () => {
+    const result = validateCardPlatforms(['github', 'github']);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Duplicate'))).toBe(true);
+  });
+
+  it('passes with exactly 10 platforms', () => {
+    const platforms = ['github','linkedin','twitter','youtube','twitch',
+                       'discord','devto','medium','dribbble','leetcode'];
+    const result = validateCardPlatforms(platforms);
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails with more than 10 platforms', () => {
+    const platforms = ['github','linkedin','twitter','youtube','twitch',
+                       'discord','devto','medium','dribbble','leetcode','npm'];
+    const result = validateCardPlatforms(platforms);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Maximum 10'))).toBe(true);
+  });
+
+  it('fails with all invalid platforms', () => {
+    const result = validateCardPlatforms(['myspace', 'bebo']);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('diffCardPlatforms', () => {
+  it('correctly identifies added, removed, unchanged', () => {
+    const diff = diffCardPlatforms(['github', 'linkedin'], ['github', 'twitter']);
+    expect(diff.added).toEqual(['twitter']);
+    expect(diff.removed).toEqual(['linkedin']);
+    expect(diff.unchanged).toEqual(['github']);
+  });
+
+  it('handles empty old card', () => {
+    const diff = diffCardPlatforms([], ['github']);
+    expect(diff.added).toEqual(['github']);
+    expect(diff.removed).toEqual([]);
+    expect(diff.unchanged).toEqual([]);
+  });
+
+  it('handles identical cards', () => {
+    const diff = diffCardPlatforms(['github'], ['github']);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.unchanged).toEqual(['github']);
+  });
+});

--- a/packages/shared/src/cards.ts
+++ b/packages/shared/src/cards.ts
@@ -1,0 +1,50 @@
+export type CardValidationResult = {
+  valid: boolean;
+  errors: string[];
+};
+
+const PLATFORMS = new Set([
+  'github', 'linkedin', 'twitter', 'instagram', 'youtube',
+  'twitch', 'discord', 'devto', 'hashnode', 'medium',
+  'dribbble', 'behance', 'figma', 'stackoverflow', 'leetcode',
+  'codepen', 'replit', 'npm', 'producthunt', 'website',
+]);
+
+export function validateCardPlatforms(platforms: string[]): CardValidationResult {
+  const errors: string[] = [];
+
+  if (platforms.length === 0) {
+    errors.push('At least one platform is required.');
+  }
+
+  if (platforms.length > 10) {
+    errors.push(`Maximum 10 platforms allowed, got ${platforms.length}.`);
+  }
+
+  const seen = new Set<string>();
+  for (const p of platforms) {
+    if (!PLATFORMS.has(p)) {
+      errors.push(`Unknown platform: "${p}".`);
+    }
+    if (seen.has(p)) {
+      errors.push(`Duplicate platform: "${p}".`);
+    }
+    seen.add(p);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function diffCardPlatforms(
+  oldCard: string[],
+  newCard: string[]
+): { added: string[]; removed: string[]; unchanged: string[] } {
+  const oldSet = new Set(oldCard);
+  const newSet = new Set(newCard);
+
+  return {
+    added: newCard.filter(p => !oldSet.has(p)),
+    removed: oldCard.filter(p => !newSet.has(p)),
+    unchanged: oldCard.filter(p => newSet.has(p)),
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from './platforms';
 export * from './types';
+export * from './cards';


### PR DESCRIPTION
Closes #159

Changes:
- Added ownership verification in apps/backend/src/routes/cards.ts  before creating  CardLink records
- Queries  platformLink  to verify all provided  linkIds  belong to the authenticated  userId
- Returns  403 Forbidden  with clear error message if any foreign  linkId  is detected
- Prevents IDOR vulnerability where attacker could add another user's links to their own card