### PR TITLE
feat: add custom themed scrollbar

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -104,3 +104,39 @@ a {
   transform: translateY(-2px);
   box-shadow: 0 6px 20px var(--primary-glow);
 }
+
+/* ---------- Custom themed scrollbar (issue #151) ---------- */
+
+/* Firefox */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: var(--primary) var(--bg-secondary);
+}
+
+/* WebKit (Chromium, Safari, Edge) */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--bg-secondary);
+  border-radius: 999px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  border-radius: 999px;
+  border: 2px solid var(--bg-secondary);
+  background-clip: padding-box;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: linear-gradient(135deg, var(--accent), var(--primary));
+  box-shadow: 0 0 8px var(--primary-glow);
+}
+
+::-webkit-scrollbar-corner {
+  background: var(--bg-secondary);
+}


### PR DESCRIPTION
## Summary
Replaces the default browser scrollbar with a custom themed scrollbar that uses DevCard's brand gradient (indigo → purple) and respects the existing light/dark theme variables. CSS-only, no JavaScript.

## Changes
- Added a `/* Custom themed scrollbar */` block to `apps/web/src/app.css`.
- WebKit/Chromium/Safari: styled `::-webkit-scrollbar`, `-track`, `-thumb`, `-thumb:hover`, and `-corner` pseudo-elements.
- Firefox: `scrollbar-width: thin` and `scrollbar-color` using the same theme variables (solid fallback for the thumb gradient).
- Reused existing CSS variables (`--primary`, `--accent`, `--bg-secondary`, `--primary-glow`) so the scrollbar auto-adapts when `html.dark` is toggled.

## Visual impact
- Profile view and other scroll-heavy pages now have a scrollbar that visually belongs to the app instead of the OS.
- Hovering the thumb flips the gradient direction and adds a soft indigo glow.
- Track recolors between light (`#f8fafc`) and dark (`#0f172a`) automatically.

## Browser testing
- Chrome (Chromium) — gradient thumb, hover glow
- Edge / Brave (Chromium) — same as Chrome
- Firefox — thin scrollbar, solid indigo thumb on themed track (gradient on thumb is a known Firefox limitation; fallback is intentional)
- Safari — gradient thumb, hover glow

## Notes / known limitations
- Firefox does not support gradients on `scrollbar-color`; the thumb falls back to solid `var(--primary)`. This is the standard cross-browser tradeoff.
- Pseudo-element scrollbar styles do not affect embedded third-party iframes.

Closes #151.