### PR TITLE
fix(follow): use boolean flag instead of reply.statusCode for success logging

### DIFF
--- a/apps/backend/src/routes/follow.ts
+++ b/apps/backend/src/routes/follow.ts
@@ -31,11 +31,14 @@ export async function followRoutes(app: FastifyInstance) {
     // Decrypt the stored token
     const accessToken = decrypt(oauthToken.accessToken);
 
-    try {
+try {
       let result;
+      let succeeded = false;
+
       switch (platform) {
         case 'github':
           result = await followGitHub(accessToken, targetUsername, reply);
+          succeeded = result.success === true;
           break;
         default:
           return reply.status(400).send({
@@ -43,8 +46,8 @@ export async function followRoutes(app: FastifyInstance) {
           });
       }
 
-      // If follow succeeded (or was handled by the function without throwing), log it
-      if (reply.statusCode === 200 || reply.statusCode === 204) {
+      // Log only genuine successes — not based on reply.statusCode default
+      if (succeeded) {
         app.prisma.followLog.create({
           data: {
             followerId: userId,
@@ -56,7 +59,7 @@ export async function followRoutes(app: FastifyInstance) {
         }).catch(err => app.log.error('Failed to log follow:', err));
       }
 
-      return result;
+      return result.response;
     } catch (err: any) {
       app.log.error(`Follow error for ${platform}:`, err);
       
@@ -81,7 +84,7 @@ async function followGitHub(
   accessToken: string,
   targetUsername: string,
   reply: FastifyReply
-) {
+): Promise<{ success: boolean; response: FastifyReply }> {
   const response = await fetch(`https://api.github.com/user/following/${targetUsername}`, {
     method: 'PUT',
     headers: {
@@ -92,30 +95,42 @@ async function followGitHub(
   });
 
   if (response.status === 204) {
-    return reply.send({
-      status: 'success',
-      platform: 'github',
-      targetUsername,
-      message: `Now following ${targetUsername} on GitHub`,
-    });
+    return {
+      success: true,
+      response: reply.send({
+        status: 'success',
+        platform: 'github',
+        targetUsername,
+        message: `Now following ${targetUsername} on GitHub`,
+      }),
+    };
   }
 
   if (response.status === 401 || response.status === 403) {
-    return reply.status(401).send({
-      error: 'GitHub token expired or insufficient permissions',
-      requiresAuth: true,
-    });
+    return {
+      success: false,
+      response: reply.status(401).send({
+        error: 'GitHub token expired or insufficient permissions',
+        requiresAuth: true,
+      }),
+    };
   }
 
   if (response.status === 404) {
-    return reply.status(404).send({
-      error: `GitHub user '${targetUsername}' not found`,
-    });
+    return {
+      success: false,
+      response: reply.status(404).send({
+        error: `GitHub user '${targetUsername}' not found`,
+      }),
+    };
   }
 
   const errorBody = await response.text();
-  return reply.status(response.status).send({
-    error: 'GitHub follow failed',
-    details: errorBody,
-  });
+  return {
+    success: false,
+    response: reply.status(response.status).send({
+      error: 'GitHub follow failed',
+      details: errorBody,
+    }),
+  };
 }


### PR DESCRIPTION
## Summary
The follow route was checking `reply.statusCode` to decide whether to log a follow
as `status: 'success'`. However, `reply.statusCode` defaults to `200` before any
response is sent — so failed follows (401, 404, or any other error from GitHub) were
also being logged as successful. This PR fixes the issue by making `followGitHub`
return a structured `{ success, response }` object, so the caller logs based on the
actual outcome of the GitHub API call rather than the default status code.

Closes #148

---
## Type of Change
- [x] Bug fix

---
## What Changed
- `apps/backend/src/routes/follow.ts` — `followGitHub`: changed return type from
  calling `reply` directly to returning `{ success: boolean, response: FastifyReply }`,
  so the actual GitHub API outcome is surfaced to the caller.
- `apps/backend/src/routes/follow.ts` — Route handler: replaced the unreliable
  `reply.statusCode === 200 || 204` check with a `succeeded` boolean flag derived
  from `result.success`, ensuring only genuine follows are logged as `'success'`.

---
## How to Test
1. Connect a GitHub account and follow a valid user — confirm a `status: 'success'`
   entry is created in `followLog`.
2. Call the follow endpoint with an expired/invalid GitHub token — confirm the response
   is `401` and `followLog` does **not** record a `status: 'success'` entry.
3. Call the follow endpoint with a non-existent GitHub username — confirm the response
   is `404` and `followLog` does **not** record a `status: 'success'` entry.
4. Call the follow endpoint for an unsupported platform — confirm `400` is returned
   and nothing is logged.

---
## Checklist

- [x] No new `console.log` or debug statements left in the code.


---

---
## Additional Context
The `followGitHub` function previously had the side effect of sending the reply itself,
which made it impossible for the caller to know the outcome without inspecting
`reply.statusCode` — which was unreliable. The new return structure keeps reply
handling inside the function while exposing the outcome cleanly to the caller. If more
platforms are added in future (e.g. `followTwitter`, `followLinkedIn`), they should
follow the same `{ success, response }` return contract.