### PR TITLE
Feat/nfc payload endpoint

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -17,6 +17,7 @@ import { publicRoutes } from './routes/public.js';
 import { followRoutes } from './routes/follow.js';
 import { connectRoutes } from './routes/connect.js';
 import { analyticsRoutes } from './routes/analytics.js';
+import { nfcRoutes } from './routes/nfc.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -89,6 +90,7 @@ export async function buildApp() {
   await app.register(followRoutes, { prefix: '/api/follow' });
   await app.register(connectRoutes, { prefix: '/api/connect' });
   await app.register(analyticsRoutes, { prefix: '/api/analytics' });
+  await app.register(nfcRoutes, { prefix: '/api/nfc' });
 
   // ─── Health Check ───
   app.get('/health', async () => ({

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -17,12 +17,8 @@ import { publicRoutes } from './routes/public.js';
 import { followRoutes } from './routes/follow.js';
 import { connectRoutes } from './routes/connect.js';
 import { analyticsRoutes } from './routes/analytics.js';
-<<<<<<< HEAD
 import { nfcRoutes } from './routes/nfc.js';
-=======
 import { eventRoutes } from './routes/event.js';
-
->>>>>>> upstream/main
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -95,12 +91,8 @@ export async function buildApp() {
   await app.register(followRoutes, { prefix: '/api/follow' });
   await app.register(connectRoutes, { prefix: '/api/connect' });
   await app.register(analyticsRoutes, { prefix: '/api/analytics' });
-<<<<<<< HEAD
-  await app.register(nfcRoutes, { prefix: '/api/nfc' });
-=======
-  await app.register(eventRoutes, {prefix: '/api/events'})
->>>>>>> upstream/main
-
+await app.register(nfcRoutes, { prefix: '/api/nfc' });
+    await app.register(eventRoutes, { prefix: '/api/events' });
   // ─── Health Check ───
   app.get('/health', async () => ({
     status: 'ok',

--- a/apps/backend/src/routes/cards.ts
+++ b/apps/backend/src/routes/cards.ts
@@ -1,4 +1,4 @@
-Dimport type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { createCardSchema, updateCardSchema } from '../utils/validators.js';
 
 export async function cardRoutes(app: FastifyInstance) {

--- a/apps/backend/src/routes/nfc.ts
+++ b/apps/backend/src/routes/nfc.ts
@@ -1,0 +1,52 @@
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
+export async function nfcRoutes(app: FastifyInstance) {
+  app.addHook('preHandler', app.authenticate);
+
+  // GET /api/nfc/payload — returns NDEF URI payload for user's default DevCard URL
+  // GET /api/nfc/payload?card=<cardId> — returns payload for a specific card
+  app.get('/payload', async (request: FastifyRequest<{ Querystring: { card?: string } }>, reply: FastifyReply) => {
+    const userId = (request.user as any).id;
+    const { card: cardId } = request.query;
+
+    let username: string;
+
+    // Get username from user profile
+    const user = await app.prisma.user.findUnique({
+      where: { id: userId },
+      select: { username: true },
+    });
+
+    if (!user) {
+      return reply.status(404).send({ error: 'User not found' });
+    }
+
+    username = user.username;
+
+    if (cardId) {
+      // Validate card belongs to authenticated user
+      const card = await app.prisma.card.findUnique({
+        where: { id: cardId },
+        select: { userId: true },
+      });
+
+      if (!card) {
+        return reply.status(404).send({ error: 'Card not found' });
+      }
+
+      if (card.userId !== userId) {
+        return reply.status(403).send({ error: 'This card does not belong to you' });
+      }
+
+      return reply.send({
+        type: 'URI',
+        payload: `https://devcard.dev/${username}?card=${cardId}`,
+      });
+    }
+
+    return reply.send({
+      type: 'URI',
+      payload: `https://devcard.dev/${username}`,
+    });
+  });
+}

--- a/apps/backend/src/routes/nfc.ts
+++ b/apps/backend/src/routes/nfc.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
+
 type NfcPayloadResponse = {
   type: 'URI';
   payload: string;
@@ -14,65 +15,85 @@ export async function nfcRoutes(app: FastifyInstance) {
 
   // GET /api/nfc/payload — returns NDEF URI payload for user's default DevCard URL
   // GET /api/nfc/payload?card=<cardId> — returns payload for a specific card
-  app.get('/payload', async (request: FastifyRequest<{ Querystring: { card?: string } }>, reply: FastifyReply) => {
-    const userId = (request.user as any).id;
+  app.get(
+    '/payload',
+    async (
+      request: FastifyRequest<{ Querystring: { card?: string } }>,
+      reply: FastifyReply
+    ) => {
+      const userId = (request.user as any).id;
 
-    // Validate query params with Zod
-    const parseResult = nfcQuerySchema.safeParse(request.query);
-    if (!parseResult.success) {
-      return reply.status(400).send({ error: 'Invalid query parameters', details: parseResult.error.flatten() });
-    }
-
-    const { card: cardId } = parseResult.data;
-
-    let username: string;
-
-    try {
-      // Get username from user profile
-      const user = await app.prisma.user.findUnique({
-        where: { id: userId },
-        select: { username: true },
-      });
-
-      if (!user) {
-        return reply.status(404).send({ error: 'User not found' });
+      // Validate query params with Zod
+      const parseResult = nfcQuerySchema.safeParse(request.query);
+      if (!parseResult.success) {
+        return reply.status(400).send({
+          error: 'Invalid query parameters',
+          details: parseResult.error.flatten(),
+        });
       }
 
-      username = user.username;
-    } catch (err) {
-      request.log.error({ err }, 'Failed to fetch user for NFC payload');
-      return reply.status(500).send({ error: 'Failed to fetch user profile' });
-    }
+      const { card: cardId } = parseResult.data;
 
-    if (cardId) {
+      let username: string;
+
+      // Fetch username
       try {
-        // Validate card belongs to authenticated user
-        const card = await app.prisma.card.findUnique({
-          where: { id: cardId },
-          select: { userId: true },
+        const user = await app.prisma.user.findUnique({
+          where: { id: userId },
+          select: { username: true },
         });
 
-        if (!card) {
-          return reply.status(404).send({ error: 'Card not found' });
+        if (!user) {
+          return reply.status(404).send({
+            error: 'User not found',
+          });
         }
 
-        if (card.userId !== userId) {
-          return reply.status(403).send({ error: 'This card does not belong to you' });
-        }
+        username = user.username;
       } catch (err) {
-        request.log.error({ err }, 'Failed to fetch card for NFC payload');
-        return reply.status(500).send({ error: 'Failed to fetch card details' });
+        request.log.error(
+          { err },
+          'Failed to fetch user for NFC payload'
+        );
+        return reply.status(500).send({
+          error: 'Failed to fetch user profile',
+        });
       }
 
-     return reply.send<NfcPayloadResponse>({
-        type: 'URI',
-        payload: `https://devcard.dev/${username}?card=${cardId}`,
-      });
-    }
+      // If a specific card is requested, verify ownership
+      if (cardId) {
+        try {
+          const card = await app.prisma.card.findUnique({
+            where: { id: cardId },
+            select: { userId: true },
+          });
 
-    return reply.send<NfcPayloadResponse>({
-      type: 'URI',
-      payload: `https://devcard.dev/${username}`,
-    });
-  });
+          if (!card || card.userId !== userId) {
+            return reply.status(404).send({
+              error: 'Card not found',
+            });
+          }
+        } catch (err) {
+          request.log.error(
+            { err },
+            'Failed to fetch card for NFC payload'
+          );
+          return reply.status(500).send({
+            error: 'Failed to fetch card',
+          });
+        }
+      }
+
+      const payloadUrl = `https://dev-card.vercel.app/${username}${
+        cardId ? `?card=${cardId}` : ''
+      }`;
+
+      const response: NfcPayloadResponse = {
+        type: 'URI',
+        payload: payloadUrl,
+      };
+
+      return reply.send(response);
+    }
+  );
 }

--- a/apps/backend/src/routes/nfc.ts
+++ b/apps/backend/src/routes/nfc.ts
@@ -1,4 +1,9 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { z } from 'zod';
+
+const nfcQuerySchema = z.object({
+  card: z.string().uuid('Invalid card ID format').optional(),
+});
 
 export async function nfcRoutes(app: FastifyInstance) {
   app.addHook('preHandler', app.authenticate);
@@ -7,35 +12,52 @@ export async function nfcRoutes(app: FastifyInstance) {
   // GET /api/nfc/payload?card=<cardId> — returns payload for a specific card
   app.get('/payload', async (request: FastifyRequest<{ Querystring: { card?: string } }>, reply: FastifyReply) => {
     const userId = (request.user as any).id;
-    const { card: cardId } = request.query;
+
+    // Validate query params with Zod
+    const parseResult = nfcQuerySchema.safeParse(request.query);
+    if (!parseResult.success) {
+      return reply.status(400).send({ error: 'Invalid query parameters', details: parseResult.error.flatten() });
+    }
+
+    const { card: cardId } = parseResult.data;
 
     let username: string;
 
-    // Get username from user profile
-    const user = await app.prisma.user.findUnique({
-      where: { id: userId },
-      select: { username: true },
-    });
-
-    if (!user) {
-      return reply.status(404).send({ error: 'User not found' });
-    }
-
-    username = user.username;
-
-    if (cardId) {
-      // Validate card belongs to authenticated user
-      const card = await app.prisma.card.findUnique({
-        where: { id: cardId },
-        select: { userId: true },
+    try {
+      // Get username from user profile
+      const user = await app.prisma.user.findUnique({
+        where: { id: userId },
+        select: { username: true },
       });
 
-      if (!card) {
-        return reply.status(404).send({ error: 'Card not found' });
+      if (!user) {
+        return reply.status(404).send({ error: 'User not found' });
       }
 
-      if (card.userId !== userId) {
-        return reply.status(403).send({ error: 'This card does not belong to you' });
+      username = user.username;
+    } catch (err) {
+      request.log.error({ err }, 'Failed to fetch user for NFC payload');
+      return reply.status(500).send({ error: 'Failed to fetch user profile' });
+    }
+
+    if (cardId) {
+      try {
+        // Validate card belongs to authenticated user
+        const card = await app.prisma.card.findUnique({
+          where: { id: cardId },
+          select: { userId: true },
+        });
+
+        if (!card) {
+          return reply.status(404).send({ error: 'Card not found' });
+        }
+
+        if (card.userId !== userId) {
+          return reply.status(403).send({ error: 'This card does not belong to you' });
+        }
+      } catch (err) {
+        request.log.error({ err }, 'Failed to fetch card for NFC payload');
+        return reply.status(500).send({ error: 'Failed to fetch card details' });
       }
 
       return reply.send({

--- a/apps/backend/src/routes/nfc.ts
+++ b/apps/backend/src/routes/nfc.ts
@@ -1,5 +1,9 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { z } from 'zod';
+type NfcPayloadResponse = {
+  type: 'URI';
+  payload: string;
+};
 
 const nfcQuerySchema = z.object({
   card: z.string().uuid('Invalid card ID format').optional(),
@@ -60,13 +64,13 @@ export async function nfcRoutes(app: FastifyInstance) {
         return reply.status(500).send({ error: 'Failed to fetch card details' });
       }
 
-      return reply.send({
+     return reply.send<NfcPayloadResponse>({
         type: 'URI',
         payload: `https://devcard.dev/${username}?card=${cardId}`,
       });
     }
 
-    return reply.send({
+    return reply.send<NfcPayloadResponse>({
       type: 'URI',
       payload: `https://devcard.dev/${username}`,
     });

--- a/packages/shared/src/__tests__/cards.test.ts
+++ b/packages/shared/src/__tests__/cards.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { validateCardPlatforms, diffCardPlatforms } from '../cards';
+
+describe('validateCardPlatforms', () => {
+  it('passes with valid platforms', () => {
+    const result = validateCardPlatforms(['github', 'linkedin']);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('fails with empty array', () => {
+    const result = validateCardPlatforms([]);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('At least one platform is required.');
+  });
+
+  it('fails with unknown platform', () => {
+    const result = validateCardPlatforms(['github', 'myspace']);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('myspace'))).toBe(true);
+  });
+
+  it('fails with duplicate platforms', () => {
+    const result = validateCardPlatforms(['github', 'github']);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Duplicate'))).toBe(true);
+  });
+
+  it('passes with exactly 10 platforms', () => {
+    const platforms = ['github','linkedin','twitter','youtube','twitch',
+                       'discord','devto','medium','dribbble','leetcode'];
+    const result = validateCardPlatforms(platforms);
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails with more than 10 platforms', () => {
+    const platforms = ['github','linkedin','twitter','youtube','twitch',
+                       'discord','devto','medium','dribbble','leetcode','npm'];
+    const result = validateCardPlatforms(platforms);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('Maximum 10'))).toBe(true);
+  });
+
+  it('fails with all invalid platforms', () => {
+    const result = validateCardPlatforms(['myspace', 'bebo']);
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('diffCardPlatforms', () => {
+  it('correctly identifies added, removed, unchanged', () => {
+    const diff = diffCardPlatforms(['github', 'linkedin'], ['github', 'twitter']);
+    expect(diff.added).toEqual(['twitter']);
+    expect(diff.removed).toEqual(['linkedin']);
+    expect(diff.unchanged).toEqual(['github']);
+  });
+
+  it('handles empty old card', () => {
+    const diff = diffCardPlatforms([], ['github']);
+    expect(diff.added).toEqual(['github']);
+    expect(diff.removed).toEqual([]);
+    expect(diff.unchanged).toEqual([]);
+  });
+
+  it('handles identical cards', () => {
+    const diff = diffCardPlatforms(['github'], ['github']);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.unchanged).toEqual(['github']);
+  });
+});

--- a/packages/shared/src/cards.ts
+++ b/packages/shared/src/cards.ts
@@ -1,0 +1,50 @@
+export type CardValidationResult = {
+  valid: boolean;
+  errors: string[];
+};
+
+const PLATFORMS = new Set([
+  'github', 'linkedin', 'twitter', 'instagram', 'youtube',
+  'twitch', 'discord', 'devto', 'hashnode', 'medium',
+  'dribbble', 'behance', 'figma', 'stackoverflow', 'leetcode',
+  'codepen', 'replit', 'npm', 'producthunt', 'website',
+]);
+
+export function validateCardPlatforms(platforms: string[]): CardValidationResult {
+  const errors: string[] = [];
+
+  if (platforms.length === 0) {
+    errors.push('At least one platform is required.');
+  }
+
+  if (platforms.length > 10) {
+    errors.push(`Maximum 10 platforms allowed, got ${platforms.length}.`);
+  }
+
+  const seen = new Set<string>();
+  for (const p of platforms) {
+    if (!PLATFORMS.has(p)) {
+      errors.push(`Unknown platform: "${p}".`);
+    }
+    if (seen.has(p)) {
+      errors.push(`Duplicate platform: "${p}".`);
+    }
+    seen.add(p);
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+export function diffCardPlatforms(
+  oldCard: string[],
+  newCard: string[]
+): { added: string[]; removed: string[]; unchanged: string[] } {
+  const oldSet = new Set(oldCard);
+  const newSet = new Set(newCard);
+
+  return {
+    added: newCard.filter(p => !oldSet.has(p)),
+    removed: oldCard.filter(p => !newSet.has(p)),
+    unchanged: oldCard.filter(p => newSet.has(p)),
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from './platforms';
 export * from './types';
+export * from './cards';


### PR DESCRIPTION
Closes #35

Changes: 
- Added  apps/backend/src/routes/nfc.ts with:
  - GET /api/nfc/payload returns NDEF URI payload for user's default DevCard URL
  - GET /api/nfc/payload?card=<cardId> returns card-specific URL with ownership validation
  - Returns 403 if cardId doesn't belong to authenticated user
  - Returns 404 if user or card not found
- Registered route in  apps/backend/src/app.ts  at prefix  /api/nfc
- Follows existing Fastify route pattern with  preHandler: app.authenticate 