### PR TITLE
fix: improve type safety and error handling in public.ts

### DIFF
--- a/apps/backend/src/routes/public.ts
+++ b/apps/backend/src/routes/public.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { generateQRBuffer, generateQRSvg } from '../utils/qr.js';
+import { getErrorMessage } from '../utils/error.util.js';
 
 type PublicProfileLink = {
   id: string;
@@ -107,7 +108,7 @@ export async function publicRoutes(app: FastifyInstance) {
           viewerAgent: request.headers['user-agent'] || null,
           source: (request.query as any)?.source || 'link',
         },
-      }).catch(err => app.log.error('Failed to log view:', err));
+      }).catch((err: unknown) => app.log.error('Failed to log view:', getErrorMessage(err)));
     }
 
     const response: UsernamePublicProfileResponse = {
@@ -167,7 +168,7 @@ export async function publicRoutes(app: FastifyInstance) {
         avatarUrl: card.user.avatarUrl,
         accentColor: card.user.accentColor,
       },
-      links: card.cardLinks.map((cl) => ({
+      links: card.cardLinks.map((cl: { platformLink: { id: string; platform: string; username: string; url: string }; displayOrder: number }) => ({
         id: cl.platformLink.id,
         platform: cl.platformLink.platform,
         username: cl.platformLink.username,
@@ -230,7 +231,7 @@ export async function publicRoutes(app: FastifyInstance) {
           viewerAgent: request.headers['user-agent'] || null,
           source: (request.query as any)?.source || 'qr',
         },
-      }).catch(err => app.log.error('Failed to log card view:', err));
+      }).catch((err: unknown) => app.log.error('Failed to log card view:', getErrorMessage(err)));
     }
 
 
@@ -246,7 +247,7 @@ export async function publicRoutes(app: FastifyInstance) {
         avatarUrl: user.avatarUrl,
         accentColor: user.accentColor,
       },
-      links: card.cardLinks.map((cl) => ({
+      links: card.cardLinks.map((cl: { platformLink: { id: string; platform: string; username: string; url: string }; displayOrder: number }) => ({
         id: cl.platformLink.id,
         platform: cl.platformLink.platform,
         username: cl.platformLink.username,


### PR DESCRIPTION
## Summary
Improve type safety and error handling in `apps/backend/src/routes/public.ts` by:
- Importing and using the shared `getErrorMessage(err)` utility for standardized error extraction in catch blocks
- Adding explicit type annotations for the `cl` parameter in `card.cardLinks.map()` to eliminate implicit `any` warnings

## Related
Closes #196

## Testing
- TypeScript type annotations added for `cl` parameter in both `card.cardLinks.map()` calls
- Catch blocks now use `getErrorMessage(err: unknown)` instead of logging raw error objects
- No behavioral changes — only type safety and error logging improvements
