### PR TITLE
fix(cards): verify linkIds belong to authenticated user before creating CardLinks

### DIFF
--- a/apps/backend/src/routes/cards.ts
+++ b/apps/backend/src/routes/cards.ts
@@ -96,6 +96,30 @@ export async function cardRoutes(app: FastifyInstance): Promise<void> {
     }
 
     if (parsed.data.linkIds) {
+ // Update card links if provided
+    if (parsed.data.linkIds) {
+      // Verify ALL provided linkIds belong to the authenticated user
+      // before touching anything — prevents link ownership hijacking
+      const validLinks = await app.prisma.platformLink.findMany({
+        where: { id: { in: parsed.data.linkIds }, userId },
+        take: 50, // guard against unbounded queries
+      });
+
+      if (validLinks.length !== parsed.data.linkIds.length) {
+        return reply.status(403).send({ error: 'One or more links do not belong to you' });
+      }
+
+      // Remove existing links
+      await app.prisma.cardLink.deleteMany({ where: { cardId: id } });
+      // Add new links
+      await app.prisma.cardLink.createMany({
+        data: parsed.data.linkIds.map((linkId, index) => ({
+          cardId: id,
+          platformLinkId: linkId,
+          displayOrder: index,
+        })),
+      });
+    }
       await app.prisma.cardLink.deleteMany({ where: { cardId: id } });
 
       


### PR DESCRIPTION
## Summary
The `PUT /:id` endpoint in the cards route accepted `linkIds` and created `CardLink`
records without verifying that the provided `platformLinkId` values actually belonged
to the authenticated user. This meant an attacker who knew another user's
`platformLinkId` UUID could silently embed that user's profile links into their own
card, effectively stealing their link data. The fix adds an ownership check against
the `platformLink` table before any delete or create operations are performed — if
any single `linkId` does not belong to the requesting user, the entire operation is
rejected with a `403`.

Closes #159 

---
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [x] Security

---
## What Changed
- `apps/backend/src/routes/cards.ts` — `PUT /:id` handler: added a
  `platformLink.findMany` query before the delete/create block that checks every
  provided `linkId` has `userId` matching the authenticated user. If the count of
  valid links doesn't match the count of provided `linkIds`, returns `403` and
  halts the operation before any data is modified.

---
## How to Test
1. Create two accounts (User A and User B). Add a platform link to User A's profile
   and note the returned `platformLinkId` UUID.
2. Log in as User B, create a card, then call `PUT /api/cards/:id` with User A's
   `platformLinkId` in the `linkIds` array — confirm the server returns `403` with
   `"One or more links do not belong to you"` and no data is changed.
3. Log in as User A and call `PUT /api/cards/:id` with their own valid `linkIds` —
   confirm the update succeeds normally and the card reflects the new links.
4. Call `PUT /api/cards/:id` with a mix of valid and foreign `linkIds` — confirm
   the server still returns `403` and does not partially apply the update.

---
## Checklist
- [ ] My code follows the project's coding style (`pnpm -r run lint` passes).
- [ ] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [ ] I have added or updated tests for the changes I made.
- [ ] All tests pass locally (`pnpm -r run test`).
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description.

---
## Screenshots / Recordings
N/A — backend security fix with no UI changes.

---
## Additional Context
The ownership check is intentionally placed **before** the `deleteMany` call. This
is important — without it, the existing links would be wiped first and then the
403 would fire, leaving the card in a broken empty state. The current order ensures
the operation is fully atomic from the user's perspective: either everything
succeeds or nothing changes. If the project later moves this logic into a Prisma
transaction, the same ordering should be preserved.

Please also add the appropriate labels so that I can recieve points in GSSoC