### PR TITLE
fix(events): resolve double-prefix routing for event endpoints 

### DIFF
--- a/apps/backend/src/__tests__/event.test.ts
+++ b/apps/backend/src/__tests__/event.test.ts
@@ -78,7 +78,9 @@ async function buildApp(): Promise<FastifyInstance> {
     return mockJwtVerify();
   });
 
-  await app.register(eventRoutes);
+  // Register with the same prefix used in production (app.ts) so that
+  // tests exercise routes at their real paths — /api/events, /api/events/:slug, etc.
+  await app.register(eventRoutes, { prefix: '/api/events' });
   await app.ready();
   return app;
 }

--- a/apps/backend/src/routes/event.ts
+++ b/apps/backend/src/routes/event.ts
@@ -36,13 +36,13 @@ type PaginatedAttendeesResponse = {
 }
 
 export async function eventRoutes(app:FastifyInstance) {
-    app.post('/api/events' , async(request: FastifyRequest<{
+    app.post('/' , async(request: FastifyRequest<{
         Body: {
             name: string,
-            description?: string, 
-            startDate: string, 
+            description?: string,
+            startDate: string,
             location: string,
-            endDate: string, 
+            endDate: string,
             isPublic?: boolean
     }}>, reply: FastifyReply) => {
         let decoded; 
@@ -98,7 +98,7 @@ export async function eventRoutes(app:FastifyInstance) {
     })
 
     //Returns event details and attendees count
-    app.get('/api/events/:slug', async(request: FastifyRequest<{Params: {slug: string}}>, reply: FastifyReply) => {
+    app.get('/:slug', async(request: FastifyRequest<{Params: {slug: string}}>, reply: FastifyReply) => {
         const paramsSlug = request.params.slug; 
         const details = await app.prisma.event.findUnique({
             where: {
@@ -132,7 +132,7 @@ export async function eventRoutes(app:FastifyInstance) {
         return response; 
     })
 
-    app.post('/api/events/:slug/join' , async(request: FastifyRequest<{Params: {slug: string}}>, reply: FastifyReply) => {
+    app.post('/:slug/join' , async(request: FastifyRequest<{Params: {slug: string}}>, reply: FastifyReply) => {
         let decoded; 
         try {
             decoded = await request.jwtVerify() as any; 
@@ -172,7 +172,7 @@ export async function eventRoutes(app:FastifyInstance) {
 
     })
 
-    app.delete('/api/events/:slug/leave',async(request: FastifyRequest<{Params: {slug: string}}>, reply: FastifyReply) => {
+    app.delete('/:slug/leave',async(request: FastifyRequest<{Params: {slug: string}}>, reply: FastifyReply) => {
         let decoded; 
         try {
             decoded = await request.jwtVerify() as any
@@ -211,7 +211,7 @@ export async function eventRoutes(app:FastifyInstance) {
         }
     })
 
-    app.get('/api/events/:slug/attendees', async(request: FastifyRequest<{Params: {slug: string}, Querystring: {page?:string; limit?: string}}>, reply: FastifyReply) => {
+    app.get('/:slug/attendees', async(request: FastifyRequest<{Params: {slug: string}, Querystring: {page?:string; limit?: string}}>, reply: FastifyReply) => {
         const paramsSlug = request.params.slug; 
         const page = Math.max(1, Number(request.query.page) || 1); 
         const limit = Math.min(50, Number(request.query.limit) || 10); 


### PR DESCRIPTION
## Problem

All five `eventRoutes` handlers defined absolute `/api/events*` paths inside the plugin:

```ts
app.post('/api/events', ...)
app.get('/api/events/:slug', ...)
```

At the same time, `app.ts` registers the plugin with:

```ts
prefix: '/api/events'
```

Fastify concatenates both values during route registration, producing routes like:

```txt
/api/events/api/events
/api/events/api/events/:slug
```

instead of the intended:

```txt
/api/events
/api/events/:slug
```

As a result, all event endpoints became unreachable at their documented production URLs.

---

## Root Cause

`event.ts` was the only route plugin in the codebase using absolute paths internally instead of relative plugin paths.

The issue remained undetected because the test setup registered the plugin without the production prefix, causing tests to pass despite the broken production routing behavior.

---

## Fix

Updated all route definitions inside `apps/backend/src/routes/event.ts` to use relative plugin paths instead of hardcoded `/api/events*` paths.

Examples:

```ts
// Before
app.post('/api/events', ...)
app.get('/api/events/:slug', ...)

// After
app.post('/', ...)
app.get('/:slug', ...)
```

Also updated the test setup in:

```txt
apps/backend/src/__tests__/event.test.ts
```

to register the plugin using:

```ts
{ prefix: '/api/events' }
```

so test registration now accurately mirrors production behavior.

---

## Changes

### `apps/backend/src/routes/event.ts`
- removed duplicated `/api/events` prefixes from all route definitions
- converted routes to relative Fastify plugin paths

### `apps/backend/src/__tests__/event.test.ts`
- updated plugin registration to use the production route prefix
- ensured tests validate actual production route behavior

---

## Resulting Route Behavior

| Method | Route |
|---|---|
| POST | `/api/events` |
| GET | `/api/events/:slug` |
| POST | `/api/events/:slug/join` |
| DELETE | `/api/events/:slug/leave` |
| GET | `/api/events/:slug/attendees` |

---

## Testing

- Existing event route tests continue passing
- Test setup now mirrors production route registration
- Verified no remaining duplicated `/api/events/api/events` routes exist
- No business logic or API contract changes introduced

---

## Impact

This restores all event endpoints to their intended production URLs and prevents future route-registration mismatches from being silently masked by the test environment.

Fixes #224