### PR TITLE
fix: remove sticky positioning from nav for natural scrolling

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -101,13 +101,10 @@
   }
 
   nav {
-    position: sticky;
-    top: 1.25rem;
-    margin: 0 auto;
+    margin: 1.25rem auto 0;
     width: min(1100px, calc(100% - 2rem));
     max-width: 1100px;
     border-radius: var(--radius-xl);
-    z-index: 100;
     padding: 1rem 1.5rem;
   }
 
@@ -278,7 +275,6 @@
 
   @media (max-width: 860px) {
     nav {
-      top: 0.9rem;
       padding: 0.85rem 1.1rem;
     }
 


### PR DESCRIPTION
## Summary

Removes position: sticky from the landing page navigation so it scrolls naturally with the page instead of staying fixed at the top.

## Changes
- Remove position: sticky and 	op from the <nav> element on the landing page
- Remove the responsive 	op override at mobile breakpoint
- Remove unnecessary z-index: 100 on the nav

Closes #221