### PR TITLE
fix(events): fix incorrect pagination total in GET /api/events/:slug/attendees

### DIFF
--- a/apps/backend/src/routes/event.ts
+++ b/apps/backend/src/routes/event.ts
@@ -221,6 +221,9 @@ export async function eventRoutes(app:FastifyInstance) {
                 slug: paramsSlug
             }, 
             include: {
+                _count: {
+                    select: { attendees: true }
+                },
                 attendees : {
                     include: {
                         user: {
@@ -264,7 +267,7 @@ export async function eventRoutes(app:FastifyInstance) {
             pagination: {
                 page, 
                 limit, 
-                total : event.attendees.length,
+                total : event._count.attendees,
             }
         }
 


### PR DESCRIPTION
## Problem
The attendees endpoint computed `pagination.total` as `event.attendees.length`, which is the length of the already-paginated
slice returned by Prisma's skip/take. So total was always at most 50 (the page size cap), never the real attendee count. Any client using this field to compute total pages would show wrong results.

## Fix
Added `_count: { select: { attendees: true } }` to the existing findUnique include block — one atomic query, no extra round trip.
Replaced `event.attendees.length` with `event._count.attendees` in the pagination response.

## Testing
- Existing test suite passes
- pagination.total now reflects real attendee count across all pages

Closes #201 