### PR TITLE
Add profile platform link route tests

### DIFF
--- a/apps/backend/src/__tests__/profiles.test.ts
+++ b/apps/backend/src/__tests__/profiles.test.ts
@@ -20,12 +20,28 @@ const mockUser = {
   providerId: 'gh-123',
 };
 
-const mockPrisma: Pick<PrismaClient, 'user'> = {
+const mockUserFindUnique = vi.fn();
+const mockUserFindFirst = vi.fn();
+const mockUserUpdate = vi.fn();
+const mockPlatformLinkAggregate = vi.fn();
+const mockPlatformLinkCreate = vi.fn();
+const mockPlatformLinkFindFirst = vi.fn();
+const mockPlatformLinkUpdate = vi.fn();
+const mockPlatformLinkDelete = vi.fn();
+
+const mockPrisma = {
   user: {
-    findUnique: vi.fn(),
-    findFirst: vi.fn(),
-    update: vi.fn(),
-  } as unknown as PrismaClient['user'],
+    findUnique: mockUserFindUnique,
+    findFirst: mockUserFindFirst,
+    update: mockUserUpdate,
+  },
+  platformLink: {
+    aggregate: mockPlatformLinkAggregate,
+    create: mockPlatformLinkCreate,
+    findFirst: mockPlatformLinkFindFirst,
+    update: mockPlatformLinkUpdate,
+    delete: mockPlatformLinkDelete,
+  },
 };
 
 async function buildApp() {
@@ -43,7 +59,7 @@ describe('GET /api/profiles/me', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('should return user profile with displayName', async () => {
-    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+    mockUserFindUnique.mockResolvedValue(mockUser);
     const app = await buildApp();
     const res = await app.inject({ method: 'GET', url: '/api/profiles/me' });
     expect(res.statusCode).toBe(200);
@@ -55,7 +71,7 @@ describe('GET /api/profiles/me', () => {
   });
 
   it('should return 404 if user not found', async () => {
-    mockPrisma.user.findUnique.mockResolvedValue(null);
+    mockUserFindUnique.mockResolvedValue(null);
     const app = await buildApp();
     const res = await app.inject({ method: 'GET', url: '/api/profiles/me' });
     expect(res.statusCode).toBe(404);
@@ -67,8 +83,8 @@ describe('PUT /api/profiles/me', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('should update profile and return updated data', async () => {
-    mockPrisma.user.findFirst.mockResolvedValue(null);
-    mockPrisma.user.update.mockResolvedValue({ ...mockUser, displayName: 'Updated Name' });
+    mockUserFindFirst.mockResolvedValue(null);
+    mockUserUpdate.mockResolvedValue({ ...mockUser, displayName: 'Updated Name' });
     const app = await buildApp();
     const res = await app.inject({
       method: 'PUT',
@@ -91,7 +107,7 @@ describe('PUT /api/profiles/me', () => {
   });
 
   it('should return 409 if username is already taken', async () => {
-    mockPrisma.user.findFirst.mockResolvedValue({ id: 'other-user' });
+    mockUserFindFirst.mockResolvedValue({ id: 'other-user' });
     const app = await buildApp();
     const res = await app.inject({
       method: 'PUT',
@@ -100,5 +116,102 @@ describe('PUT /api/profiles/me', () => {
     });
     expect(res.statusCode).toBe(409);
     expect(res.json().error).toBe('Username already taken');
+  });
+});
+
+describe('Platform link routes', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('should return 400 for invalid link create body', async () => {
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/profiles/me/links',
+      payload: { platform: '', username: '' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe('Validation failed');
+    expect(mockPlatformLinkCreate).not.toHaveBeenCalled();
+  });
+
+  it('should create a platform link with a valid body', async () => {
+    const createdLink = {
+      id: 'link-123',
+      userId: 'user-123',
+      platform: 'github',
+      username: 'octocat',
+      url: 'https://github.com/octocat',
+      displayOrder: 2,
+    };
+
+    mockPlatformLinkAggregate.mockResolvedValue({ _max: { displayOrder: 1 } });
+    mockPlatformLinkCreate.mockResolvedValue(createdLink);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/profiles/me/links',
+      payload: { platform: 'github', username: 'octocat' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual(createdLink);
+    expect(mockPlatformLinkAggregate).toHaveBeenCalledWith({
+      where: { userId: 'user-123' },
+      _max: { displayOrder: true },
+    });
+    expect(mockPlatformLinkCreate).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-123',
+        platform: 'github',
+        username: 'octocat',
+        url: expect.stringContaining('octocat'),
+        displayOrder: 2,
+      },
+    });
+  });
+
+  it('should return 404 when updating a link that does not exist', async () => {
+    mockPlatformLinkFindFirst.mockResolvedValue(null);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/api/profiles/me/links/link-404',
+      payload: { platform: 'github', username: 'octocat' },
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toBe('Link not found');
+    expect(mockPlatformLinkFindFirst).toHaveBeenCalledWith({
+      where: { id: 'link-404', userId: 'user-123' },
+    });
+    expect(mockPlatformLinkUpdate).not.toHaveBeenCalled();
+  });
+
+  it('should delete an existing platform link', async () => {
+    mockPlatformLinkFindFirst.mockResolvedValue({
+      id: 'link-123',
+      userId: 'user-123',
+      platform: 'github',
+      username: 'octocat',
+      url: 'https://github.com/octocat',
+      displayOrder: 0,
+    });
+    mockPlatformLinkDelete.mockResolvedValue({ id: 'link-123' });
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/profiles/me/links/link-123',
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(res.body).toBe('');
+    expect(mockPlatformLinkFindFirst).toHaveBeenCalledWith({
+      where: { id: 'link-123', userId: 'user-123' },
+    });
+    expect(mockPlatformLinkDelete).toHaveBeenCalledWith({ where: { id: 'link-123' } });
   });
 });


### PR DESCRIPTION
## Summary

The profiles API currently lacks focused backend coverage for creating, updating, and deleting platform links, making validation and typed response behavior harder to verify. This change adds Vitest coverage for POST /api/profiles/me/links validation and success paths, PUT /api/profiles/me/links/:id not-found handling, and DELETE /api/profiles/me/links/:id successful deletion using mocked Prisma platformLink methods.

## Changes

- Extended the profiles route test Prisma mock to include platformLink methods used by link routes.
- Added a POST /api/profiles/me/links invalid body test covering createLinkSchema.safeParse failure and ensuring no link is created.
- Added a POST /api/profiles/me/links valid body test covering successful link creation and expected Prisma create data.
- Added a PUT /api/profiles/me/links/:id test verifying a missing link returns 404 and does not call update.
- Added a DELETE /api/profiles/me/links/:id test verifying an existing authenticated link can be deleted with a 204 response.

## Validation

- pnpm run test is the provided test command for the backend test suite; execution is still pending because runnable commands were not available in this environment.
- pnpm run lint is the provided lint command for TypeScript and formatting checks; execution is still pending because runnable commands were not available in this environment.

## Risks

- Mocking Prisma platformLink methods may require local test type adjustments if the existing mock is narrowly typed.
- Assertions around generated platform URLs may be brittle if shared platform URL generation behavior changes.
- DELETE 204 responses have an empty body, so tests must avoid parsing JSON from that response.
