### PR TITLE
fix: replace hardcoded localhost URL with BACKEND_URL env var in devcard server loader

### DIFF
--- a/apps/web/src/routes/devcard/[id]/+page.server.ts
+++ b/apps/web/src/routes/devcard/[id]/+page.server.ts
@@ -1,17 +1,28 @@
 import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
+const API_BASE = process.env.BACKEND_URL || 'http://localhost:3000';
+
 export const load: PageServerLoad = async ({ params, fetch }) => {
 	const { id } = params;
 
-	// Use internal fetch to reach the backend
-	// In production, this would be the actual API URL
-	const res = await fetch(`http://localhost:3000/api/u/card/${id}`);
+	try {
+		const res = await fetch(`${API_BASE}/api/u/card/${id}`);
 
-	if (!res.ok) {
-		throw error(404, 'Card not found');
+		if (res.status === 404) {
+			throw error(404, 'Card not found');
+		}
+
+		if (!res.ok) {
+			throw error(500, 'Failed to load card');
+		}
+
+		const card = await res.json();
+		return { card };
+	} catch (err) {
+		if (err && typeof err === 'object' && 'status' in err) {
+			throw err;
+		}
+		throw error(500, 'Failed to connect to backend');
 	}
-
-	const card = await res.json();
-	return { card };
 };


### PR DESCRIPTION
## Summary

Closes #218

The server load function for the \`/devcard/[id]\` route was fetching card data from a hardcoded \`http://localhost:3000\` URL. This meant the standalone card view always failed in production, staging, and any Docker-based environment because the backend is not reachable at localhost from the web container.

The fix replaces the hardcoded URL with \`process.env.BACKEND_URL\`, falling back to \`http://localhost:3000\` for local development. This is exactly the pattern already used by the \`/u/[username]\` route and documented in the root \`.env.example\` file.

Error handling was also improved alongside the URL fix: the fetch is now wrapped in a \`try/catch\` to handle network-level failures gracefully, 404 responses from the backend are distinguished from other error statuses, and SvelteKit \`HttpError\` objects thrown inside the block are re-thrown correctly so they are not swallowed by the outer catch.

---

## Type of Change

- [x] Bug fix

---

## What Changed

- \`apps/web/src/routes/devcard/[id]/+page.server.ts\`
  - Added \`const API_BASE = process.env.BACKEND_URL || 'http://localhost:3000'\` (matches the pattern in \`/u/[username]/+page.server.ts\`)
  - Replaced hardcoded URL with \`\${API_BASE}/api/u/card/\${id}\`
  - Wrapped fetch in try/catch to handle backend connection failures with a 500 error
  - Added separate handling for 404 vs other non-ok responses
  - Re-throws SvelteKit \`HttpError\` objects so they propagate correctly through the catch block
  - Removed stale comments that described the hardcoded URL as a known issue

---

## How to Test

1. Set \`BACKEND_URL=http://your-backend-host:3000\` in the web app environment.
2. Start the web app and navigate to \`/devcard/<id>\`.
3. Confirm the card loads correctly using the configured backend URL.
4. Unset \`BACKEND_URL\` and confirm the route falls back to \`http://localhost:3000\` (local dev behaviour unchanged).
5. Test with an invalid card ID and confirm a clean 404 page is shown.
6. Simulate a backend connection failure and confirm a clean 500 page is shown instead of an unhandled exception.

---

## Checklist

- [x] My code follows the project's coding style.
- [x] TypeScript compiles without errors.
- [x] No new \`console.log\` or debug statements left in the code.
- [x] Breaking changes are documented in this PR description.

---

## Additional Context

The \`BACKEND_URL\` variable is already documented in the root \`.env.example\` file (line 23) and used in both \`apps/backend/src/routes/auth.ts\` and \`apps/web/src/routes/u/[username]/+page.server.ts\`. This PR brings the devcard loader in line with the rest of the codebase.