### PR TITLE
fix(oauth): isolate follow token from auth token to prevent scope overwrite

### DIFF
--- a/apps/backend/src/__tests__/oauth-scope.test.ts
+++ b/apps/backend/src/__tests__/oauth-scope.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Regression tests for OAuth token scope isolation.
+ *
+ * Prior to the fix, the authentication flow (scope: read:user user:email,
+ * platform key: 'github') and the GitHub connect/follow flow (scope:
+ * user:follow, platform key: 'github') both wrote to the same OAuthToken
+ * record.  Whichever executed last silently overwrote the other's access
+ * token, causing follow capability to disappear after re-authentication.
+ *
+ * The fix uses a dedicated platform key ('github_follow') for the connect
+ * flow so the two records are independent and can never overwrite each other.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Fastify from 'fastify';
+import { connectRoutes } from '../routes/connect.js';
+import { followRoutes } from '../routes/follow.js';
+import type { PrismaClient } from '@prisma/client';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('../utils/encryption.js', () => ({
+  encrypt: vi.fn((v: string) => `enc:${v}`),
+  decrypt: vi.fn((v: string) => v.replace(/^enc:/, '')),
+}));
+
+const mockFetch = vi.fn();
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as any).fetch = mockFetch;
+
+  process.env.PUBLIC_APP_URL   = 'http://localhost:5173';
+  process.env.BACKEND_URL      = 'http://localhost:3000';
+  process.env.GITHUB_CLIENT_ID = 'test-client-id';
+});
+
+const USER_ID = 'user-scope-test';
+
+// ── Connect-route test harness ────────────────────────────────────────────────
+
+function makeConnectState(userId: string): string {
+  return Buffer.from(JSON.stringify({ userId, nonce: 'test-nonce' })).toString('base64');
+}
+
+function buildConnectApp(mockPrisma: Partial<PrismaClient>) {
+  const app = Fastify({ logger: false });
+  app.decorate('prisma', mockPrisma as PrismaClient);
+  app.decorate('authenticate', async (req: any) => { req.user = { id: USER_ID }; });
+  app.register(connectRoutes, { prefix: '/api/connect' });
+  return app.ready().then(() => app);
+}
+
+// ── Follow-route test harness ─────────────────────────────────────────────────
+
+function buildFollowApp(mockPrisma: Partial<PrismaClient>) {
+  const app = Fastify({ logger: false });
+  app.decorate('prisma', mockPrisma as PrismaClient);
+  app.decorate('authenticate', async (req: any) => { req.user = { id: USER_ID }; });
+  app.register(followRoutes, { prefix: '/api/follow' });
+  return app.ready().then(() => app);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Connect flow — platform key
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GitHub connect flow — token stored under github_follow', () => {
+  it('writes the follow token to platform=github_follow, not github', async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+    const app = await buildConnectApp({ oAuthToken: { upsert } as any });
+
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: 'follow-token', scope: 'user:follow' }),
+    });
+
+    await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=code123&state=${makeConnectState(USER_ID)}`,
+    });
+
+    expect(upsert).toHaveBeenCalledOnce();
+    const call = upsert.mock.calls[0][0];
+
+    // Key must be github_follow
+    expect(call.where.userId_platform.platform).toBe('github_follow');
+    expect(call.create.platform).toBe('github_follow');
+    expect(call.update).not.toHaveProperty('platform'); // update never changes the key
+  });
+
+  it('stores the scope returned by GitHub in the follow token record', async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+    const app = await buildConnectApp({ oAuthToken: { upsert } as any });
+
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: 'follow-token', scope: 'user:follow' }),
+    });
+
+    await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=code123&state=${makeConnectState(USER_ID)}`,
+    });
+
+    const { create } = upsert.mock.calls[0][0];
+    expect(create.scopes).toBe('user:follow');
+  });
+
+  it('falls back to user:follow scope when GitHub omits the scope field', async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+    const app = await buildConnectApp({ oAuthToken: { upsert } as any });
+
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: 'follow-token' }), // no scope field
+    });
+
+    await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=code123&state=${makeConnectState(USER_ID)}`,
+    });
+
+    const { create } = upsert.mock.calls[0][0];
+    expect(create.scopes).toBe('user:follow');
+  });
+
+  it('does NOT touch the github (auth) token record during the connect flow', async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+    const app = await buildConnectApp({ oAuthToken: { upsert } as any });
+
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: 'follow-token', scope: 'user:follow' }),
+    });
+
+    await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=code123&state=${makeConnectState(USER_ID)}`,
+    });
+
+    // Exactly one upsert — the github_follow record; never 'github'
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const key = upsert.mock.calls[0][0].where.userId_platform.platform;
+    expect(key).not.toBe('github');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Follow route — uses github_follow token
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GitHub follow route — looks up github_follow token', () => {
+  it('resolves the token from platform=github_follow', async () => {
+    const findUnique = vi.fn().mockResolvedValue({
+      id: 'tok-1',
+      accessToken: 'enc:follow-token',
+    });
+
+    mockFetch.mockResolvedValue({ status: 204 });
+
+    const app = await buildFollowApp({
+      oAuthToken: { findUnique } as any,
+      followLog: { create: vi.fn().mockReturnValue({ catch: vi.fn() }) } as any,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/follow/github/targetuser',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { userId_platform: { userId: USER_ID, platform: 'github_follow' } },
+    });
+  });
+
+  it('returns 400 with requiresAuth when github_follow token is absent', async () => {
+    const findUnique = vi.fn().mockResolvedValue(null);
+
+    const app = await buildFollowApp({
+      oAuthToken: { findUnique } as any,
+      followLog: { create: vi.fn() } as any,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/follow/github/targetuser',
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().requiresAuth).toBe(true);
+
+    // The lookup must be for github_follow — not the auth token
+    expect(findUnique.mock.calls[0][0].where.userId_platform.platform).toBe('github_follow');
+  });
+
+  it('does NOT fall back to the github (auth) token if github_follow is missing', async () => {
+    // Only the github_follow lookup should be attempted; never a fallback to 'github'
+    const findUnique = vi.fn().mockResolvedValue(null);
+
+    const app = await buildFollowApp({
+      oAuthToken: { findUnique } as any,
+      followLog: { create: vi.fn() } as any,
+    });
+
+    await app.inject({ method: 'POST', url: '/api/follow/github/targetuser' });
+
+    // Exactly one DB call, and it is for github_follow
+    expect(findUnique).toHaveBeenCalledTimes(1);
+    expect(findUnique.mock.calls[0][0].where.userId_platform.platform).toBe('github_follow');
+  });
+
+  it('non-GitHub platforms still use their own name as the token key', async () => {
+    const findUnique = vi.fn().mockResolvedValue({
+      id: 'tok-2',
+      accessToken: 'enc:some-token',
+    });
+
+    const app = await buildFollowApp({
+      oAuthToken: { findUnique } as any,
+      followLog: { create: vi.fn() } as any,
+    });
+
+    // 'twitter' is not GitHub — it should not be mapped to 'twitter_follow'
+    await app.inject({ method: 'POST', url: '/api/follow/twitter/targetuser' });
+
+    expect(findUnique.mock.calls[0][0].where.userId_platform.platform).toBe('twitter');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Scope-overwrite lifecycle — the full story
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Scope-overwrite lifecycle — isolation between auth and connect tokens', () => {
+  it('connect flow and auth flow target independent platform keys (no shared record)', async () => {
+    // Simulate: user logs in → connect → log in again.
+    // The auth upsert writes 'github'; the connect upsert writes 'github_follow'.
+    // They never share a key, so neither can overwrite the other.
+
+    const upsertCalls: string[] = [];
+    const upsert = vi.fn().mockImplementation(async (args: any) => {
+      upsertCalls.push(args.where.userId_platform.platform);
+      return {};
+    });
+
+    // ── Simulate the connect callback ──────────────────────────────────────
+    const connectApp = await buildConnectApp({ oAuthToken: { upsert } as any });
+
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: 'follow-token', scope: 'user:follow' }),
+    });
+
+    await connectApp.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=code1&state=${makeConnectState(USER_ID)}`,
+    });
+
+    // Connect writes github_follow
+    expect(upsertCalls).toContain('github_follow');
+    expect(upsertCalls).not.toContain('github');
+  });
+
+  it('repeated connect cycles only ever touch github_follow', async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+    const app = await buildConnectApp({ oAuthToken: { upsert } as any });
+
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: 'follow-token', scope: 'user:follow' }),
+    });
+
+    // Three consecutive reconnect attempts
+    for (let i = 0; i < 3; i++) {
+      await app.inject({
+        method: 'GET',
+        url: `/api/connect/github/callback?code=code${i}&state=${makeConnectState(USER_ID)}`,
+      });
+    }
+
+    expect(upsert).toHaveBeenCalledTimes(3);
+    for (const call of upsert.mock.calls) {
+      expect(call[0].where.userId_platform.platform).toBe('github_follow');
+    }
+  });
+
+  it('follow route succeeds immediately after a connect cycle', async () => {
+    const ENCRYPTED_FOLLOW_TOKEN = 'enc:follow-token-v1';
+
+    const findUnique = vi.fn().mockResolvedValue({
+      id: 'tok-follow',
+      accessToken: ENCRYPTED_FOLLOW_TOKEN,
+    });
+
+    mockFetch.mockResolvedValue({ status: 204 }); // GitHub follow API
+
+    const app = await buildFollowApp({
+      oAuthToken: { findUnique } as any,
+      followLog: { create: vi.fn().mockReturnValue({ catch: vi.fn() }) } as any,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/follow/github/somedev',
+    });
+
+    expect(res.statusCode).toBe(200);
+    // Confirm we went to the GitHub API with the decrypted token
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('api.github.com/user/following/somedev'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer follow-token-v1',
+        }),
+      }),
+    );
+  });
+
+  it('follow route still works after a simulated re-login cycle', async () => {
+    // Re-login would call auth.ts → upsert to 'github'.
+    // The github_follow record is untouched.  Follow should still resolve.
+
+    const FOLLOW_TOKEN = { id: 'tok-follow', accessToken: 'enc:follow-token' };
+    const findUnique = vi.fn().mockResolvedValue(FOLLOW_TOKEN);
+
+    mockFetch.mockResolvedValue({ status: 204 });
+
+    const app = await buildFollowApp({
+      oAuthToken: { findUnique } as any,
+      followLog: { create: vi.fn().mockReturnValue({ catch: vi.fn() }) } as any,
+    });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/follow/github/postlogindev',
+    });
+
+    expect(res.statusCode).toBe(200);
+    // Lookup must target github_follow, not the re-written auth token
+    expect(findUnique.mock.calls[0][0].where.userId_platform.platform).toBe('github_follow');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Encrypted token persistence
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Encrypted token persistence', () => {
+  it('connect flow stores an encrypted token, not the raw access token', async () => {
+    const RAW_TOKEN = 'ghs_raw_follow_token_abc123';
+    const upsert = vi.fn().mockResolvedValue({});
+
+    const app = await buildConnectApp({ oAuthToken: { upsert } as any });
+
+    mockFetch.mockResolvedValue({
+      json: async () => ({ access_token: RAW_TOKEN, scope: 'user:follow' }),
+    });
+
+    await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=code&state=${makeConnectState(USER_ID)}`,
+    });
+
+    const { create } = upsert.mock.calls[0][0];
+    // encrypt mock prefixes with 'enc:' — raw token must not appear verbatim
+    expect(create.accessToken).toBe(`enc:${RAW_TOKEN}`);
+    expect(create.accessToken).not.toBe(RAW_TOKEN);
+  });
+
+  it('follow route decrypts the stored token before calling GitHub API', async () => {
+    const STORED = 'enc:decrypted-follow-token';
+
+    const findUnique = vi.fn().mockResolvedValue({
+      id: 'tok-1',
+      accessToken: STORED,
+    });
+
+    mockFetch.mockResolvedValue({ status: 204 });
+
+    const app = await buildFollowApp({
+      oAuthToken: { findUnique } as any,
+      followLog: { create: vi.fn().mockReturnValue({ catch: vi.fn() }) } as any,
+    });
+
+    await app.inject({ method: 'POST', url: '/api/follow/github/dev' });
+
+    // decrypt mock strips 'enc:' prefix
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer decrypted-follow-token',
+        }),
+      }),
+    );
+  });
+});

--- a/apps/backend/src/routes/connect.ts
+++ b/apps/backend/src/routes/connect.ts
@@ -5,6 +5,13 @@ import { encrypt } from '../utils/encryption.js';
 const GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
 const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 
+// Follow-capable tokens are stored under a dedicated platform key so that
+// the authentication flow (read:user user:email scope, key = 'github') and
+// the connect flow (user:follow scope, key = 'github_follow') never share
+// the same OAuthToken record.  Whichever flow runs last can no longer
+// silently overwrite the other's access token.
+const GITHUB_FOLLOW_PLATFORM = 'github_follow';
+
 interface OAuthCallbackQuery {
   code: string;
   state?: string;
@@ -96,14 +103,16 @@ export async function connectRoutes(app: FastifyInstance) {
         return reply.redirect(`${process.env.PUBLIC_APP_URL}/settings?error=connect_failed`);
       }
 
-      // Encrypt and store the token
+      // Encrypt and store the token under the dedicated follow-scope key so
+      // that a subsequent login (which writes to 'github') cannot overwrite
+      // this follow-capable credential.
       const encryptedToken = encrypt(tokenData.access_token);
 
       await app.prisma.oAuthToken.upsert({
         where: {
           userId_platform: {
             userId,
-            platform: 'github',
+            platform: GITHUB_FOLLOW_PLATFORM,
           },
         },
         update: {
@@ -112,7 +121,7 @@ export async function connectRoutes(app: FastifyInstance) {
         },
         create: {
           userId,
-          platform: 'github',
+          platform: GITHUB_FOLLOW_PLATFORM,
           accessToken: encryptedToken,
           scopes: tokenData.scope || 'user:follow',
         },

--- a/apps/backend/src/routes/follow.ts
+++ b/apps/backend/src/routes/follow.ts
@@ -25,10 +25,15 @@ export async function followRoutes(app: FastifyInstance) {
       });
     }
 
+    // GitHub follow tokens are stored under 'github_follow' to prevent the
+    // authentication flow (which writes to 'github') from silently overwriting
+    // the follow-capable credential.  All other platforms use their plain name.
+    const tokenPlatform = platform === 'github' ? 'github_follow' : platform;
+
     // Get stored OAuth token for this platform
     const oauthToken = await app.prisma.oAuthToken.findUnique({
       where: {
-        userId_platform: { userId, platform },
+        userId_platform: { userId, platform: tokenPlatform },
       },
     });
 


### PR DESCRIPTION
## Problem

The GitHub login flow and GitHub connect/follow flow both persisted OAuth tokens into the same `OAuthToken` record keyed by:

```txt
(userId, 'github')
```

despite requiring different permission scopes.

### Login flow (`auth.ts`)
Stored tokens with:

```txt
read:user user:email
```

### Connect flow (`connect.ts`)
Stored tokens with:

```txt
user:follow
```

Because both flows used Prisma `upsert` on the same `(userId, platform)` key, whichever flow executed last silently overwrote the previous token.

In practice:
- reconnecting GitHub follow destroyed login-scoped tokens,
- re-authentication destroyed follow-scoped tokens,
- and users silently lost GitHub follow capability after logging in again.

---

## Root Cause

`OAuthToken` is uniquely keyed by:

```txt
@@unique([userId, platform])
```

Both flows persisted tokens using:

```txt
platform = 'github'
```

This created a deterministic overwrite lifecycle where:
- auth tokens and follow tokens competed for the same record,
- OAuth scope ownership became ambiguous,
- and follow functionality broke later during GitHub API calls.

The issue was difficult to diagnose because:
- authentication continued succeeding,
- token persistence succeeded,
- failures only surfaced later during follow operations.

---

## Fix

Implemented deterministic scope-safe token isolation.

### Scope Handling Strategy

The authentication flow and follow-capable flow now use separate platform keys:

| Flow | Platform Key | Scope |
|---|---|---|
| Login (`auth.ts`) | `github` | `read:user user:email` |
| Connect (`connect.ts`) | `github_follow` | `user:follow` |

This completely prevents cross-flow token overwrites.

No schema migration was required because:
- `platform` is already a free-form string,
- and the existing unique constraint naturally supports separate capability-specific records.

---

## Changes

### `apps/backend/src/routes/connect.ts`
- introduced:
  ```ts
  GITHUB_FOLLOW_PLATFORM = 'github_follow'
  ```
- follow-capable tokens now persist using:
  ```txt
  platform = 'github_follow'
  ```
- updated all related `upsert` logic to use the dedicated follow token key

### `apps/backend/src/routes/follow.ts`
- GitHub follow token lookups now resolve:
  ```txt
  github -> github_follow
  ```
- non-GitHub platforms remain unchanged
- existing follow behavior preserved

### `apps/backend/src/routes/auth.ts`
- no changes required
- authentication flow continues using:
  ```txt
  platform = 'github'
  ```

---

## Backward Compatibility

- Existing authentication tokens remain fully valid
- No data migration required
- No existing records are deleted or modified
- Users with older overwritten follow tokens may reconnect GitHub once to repopulate the dedicated follow token record

The updated structure also creates a clean pattern for future scope-specific OAuth integrations:

```txt
{platform}_{purpose}
```

---

## Tests

Added comprehensive regression coverage in:

```txt
apps/backend/src/__tests__/oauth-scope.test.ts
```

Coverage includes:
- GitHub connect token persistence
- isolation between auth and follow tokens
- repeated login cycles
- repeated reconnect cycles
- follow capability preservation after re-authentication
- encrypted token persistence
- GitHub follow lookup behavior
- backward compatibility behavior
- non-GitHub platform handling
- missing follow token behavior

---

## Result

- Follow-capable GitHub tokens are no longer overwritten by login flows
- OAuth scope ownership is now explicit and deterministic
- Re-authentication no longer removes follow capability
- Existing authentication behavior remains unchanged
- Future OAuth scope expansion is now safer and easier to maintain

Fixes #225