### PR TITLE
fix(auth): guard /dev-login endpoint behind NODE_ENV !== production

### DIFF
--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -15,20 +15,24 @@ interface OAuthCallbackQuery {
 }
 
 export async function authRoutes(app: FastifyInstance) {
-  // ─── Developer Login Bypass ───
-  app.post('/dev-login', async (request: FastifyRequest, reply: FastifyReply) => {
-    const user = await app.prisma.user.findUnique({
-      where: { username: 'devcard-demo' },
+  // ─── Developer Login Bypass (development only) ───
+  // This endpoint is intentionally disabled in production.
+  // It allows local dev/testing without going through a full OAuth flow.
+  if (process.env.NODE_ENV !== 'production') {
+    app.post('/dev-login', async (request: FastifyRequest, reply: FastifyReply) => {
+      const user = await app.prisma.user.findUnique({
+        where: { username: 'devcard-demo' },
+      });
+      if (!user) {
+        return reply.status(404).send({ error: 'Demo user not seeded' });
+      }
+      const token = app.jwt.sign(
+        { id: user.id, username: user.username },
+        { expiresIn: '30d' }
+      );
+      return { token };
     });
-    if (!user) {
-      return reply.status(404).send({ error: 'Demo user not seeded' });
-    }
-    const token = app.jwt.sign(
-      { id: user.id, username: user.username },
-      { expiresIn: '30d' }
-    );
-    return { token };
-  });
+  }
 
   // ─── GitHub OAuth ───
 


### PR DESCRIPTION
## Summary
Guards the `/auth/dev-login` bypass endpoint so it is only registered
when `NODE_ENV !== 'production'`. In production the route simply does
not exist — the framework returns 404 at the routing level.

## Changes
- `apps/backend/src/routes/auth.ts` — wrapped `POST /dev-login` in
  `if (process.env.NODE_ENV !== 'production')`

## Testing
- `pnpm --filter @devcard/backend test` → 46/46 passed
- Lint errors shown are pre-existing across the codebase, none
  introduced by this change

Closes #247