### PR TITLE
fix(auth): remove console.log of OAuth state tokens in auth.ts

### DIFF
--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -55,8 +55,7 @@ export async function authRoutes(app: FastifyInstance) {
     state,
   });
   const authUrl = `${GITHUB_AUTH_URL}?${params}`;
-  console.log('--- GITHUB OAUTH REDIRECT ---');
-  console.log('URL:', authUrl);
+  app.log.debug({ provider: 'github' }, 'OAuth redirect initiated');
   return reply.redirect(authUrl);
 });
 
@@ -208,8 +207,7 @@ app.get('/github/callback', async (request: FastifyRequest<{ Querystring: OAuthC
     access_type: 'offline',
   });
   const authUrl = `${GOOGLE_AUTH_URL}?${params}`;
-  console.log('--- GOOGLE OAUTH REDIRECT ---');
-  console.log('URL:', authUrl);
+  app.log.debug({ provider: 'google' }, 'OAuth redirect initiated');
   return reply.redirect(authUrl);
 });
 


### PR DESCRIPTION
## Problem
Few lines in apps/backend/src/routes/auth.ts call console.log with the full OAuth redirect URL, which includes the
`state` token. State tokens are CSRF protection secrets and must not appear in logs. This also bypasses Fastify's pino logger,
breaking structured logging and level-based filtering in production. All other paths in the codebase correctly use app.log.error.

## Fix
- Removed all 4 console.log lines from the /github and /google handlers
- Replaced with app.log.debug({ provider: '...' }, 'OAuth redirect initiated')
- No URL or state token is logged
- Uses Fastify's pino logger consistently with the rest of the codebase

## Testing
- Existing test suite passes
- console.log is no longer called during OAuth initiation

Closes #202 