### PR TITLE
test(shared): add unit tests for getProfileUrl, getWebViewUrl, getDee…

### DIFF
--- a/packages/shared/src/__tests__/platforms-url.test.ts
+++ b/packages/shared/src/__tests__/platforms-url.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { getProfileUrl, getWebViewUrl, getDeepLinkUrl } from '../platforms';
+
+// ─── getProfileUrl Tests ───
+
+describe('getProfileUrl', () => {
+  it('should return the correct GitHub profile URL', () => {
+    expect(getProfileUrl('github', 'octocat')).toBe('https://github.com/octocat');
+  });
+
+  it('should return the correct LinkedIn profile URL', () => {
+    expect(getProfileUrl('linkedin', 'john')).toBe('https://www.linkedin.com/in/john');
+  });
+
+  it('should return the correct Twitter profile URL', () => {
+    expect(getProfileUrl('twitter', 'john')).toBe('https://x.com/john');
+  });
+
+  it('should return empty string for an unknown platform', () => {
+    expect(getProfileUrl('nonexistent', 'user')).toBe('');
+  });
+});
+
+// ─── getWebViewUrl Tests ───
+
+describe('getWebViewUrl', () => {
+  it('should return the correct LinkedIn webview URL', () => {
+    expect(getWebViewUrl('linkedin', 'john')).toBe('https://www.linkedin.com/in/john');
+  });
+
+  it('should return the correct Twitter webview URL', () => {
+    expect(getWebViewUrl('twitter', 'john')).toBe('https://x.com/john');
+  });
+
+  it('should return null for platforms without a webview URL (github)', () => {
+    expect(getWebViewUrl('github', 'octocat')).toBeNull();
+  });
+
+  it('should return null for an unknown platform', () => {
+    expect(getWebViewUrl('nonexistent', 'user')).toBeNull();
+  });
+});
+
+// ─── getDeepLinkUrl Tests ───
+
+describe('getDeepLinkUrl', () => {
+  it('should return the correct Twitter deep link URL', () => {
+    expect(getDeepLinkUrl('twitter', 'john')).toBe('twitter://user?screen_name=john');
+  });
+
+  it('should return the correct LinkedIn deep link URL', () => {
+    expect(getDeepLinkUrl('linkedin', 'john')).toBe('linkedin://profile?id=john');
+  });
+
+  it('should return null for platforms without a deep link (github)', () => {
+    expect(getDeepLinkUrl('github', 'octocat')).toBeNull();
+  });
+
+  it('should return null for an unknown platform', () => {
+    expect(getDeepLinkUrl('nonexistent', 'user')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for shared URL utility functions in `packages/shared/src/platforms.ts`.

Closes #10

---

## Type of Change

* [x] Tests only

---

## What Changed

* Added `packages/shared/src/__tests__/platforms-url.test.ts`
* Added tests for:

  * `getProfileUrl('github', 'octocat')`
  * `getWebViewUrl('linkedin', 'john')`
  * `getDeepLinkUrl('twitter', 'john')`
* Added coverage for unsupported/unknown platforms returning `null`
* Followed existing Vitest testing conventions used in the repository

---

## How to Test

1. Install dependencies

```bash
pnpm install
```

2. Run shared package tests

```bash
pnpm --filter shared test
```

3. Verify all tests pass successfully

---

## Checklist

* [x] My code follows the project's coding style (`pnpm -r run lint` passes).
* [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
* [x] I have added or updated tests for the changes I made.
* [x] All tests pass locally (`pnpm -r run test`).
* [ ] I have updated documentation where necessary.
* [x] No new `console.log` or debug statements left in the code.
* [ ] Breaking changes are documented in this PR description.

---

## Additional Context

Terminal Screenshots

For tests-Passing

<img width="1590" height="774" alt="Test_shared" src="https://github.com/user-attachments/assets/337c6a2e-5120-4ea1-afb8-be44a4659595" />

for Typescripts-clean

<img width="792" height="256" alt="typeCheck" src="https://github.com/user-attachments/assets/b0fecb09-e3ac-484f-8d41-a55378162590" />

This PR focuses only on improving test coverage for shared URL utility helpers without modifying existing application behavior.

