### PR TITLE
feat(shared): add isSupportedPlatform() helper and unit tests (closes…

### DIFF
--- a/packages/shared/src/__tests__/platforms.test.ts
+++ b/packages/shared/src/__tests__/platforms.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { isSupportedPlatform } from '../platforms';
+
+// ─── isSupportedPlatform Tests ───
+
+describe('isSupportedPlatform', () => {
+  it('returns true for known platform: github', () => {
+    expect(isSupportedPlatform('github')).toBe(true);
+  });
+
+  it('returns true for known platform: linkedin', () => {
+    expect(isSupportedPlatform('linkedin')).toBe(true);
+  });
+
+  it('returns true for known platform: twitter', () => {
+    expect(isSupportedPlatform('twitter')).toBe(true);
+  });
+
+  it('returns true for known platform: discord', () => {
+    expect(isSupportedPlatform('discord')).toBe(true);
+  });
+
+  it('returns true for known platform: email', () => {
+    expect(isSupportedPlatform('email')).toBe(true);
+  });
+
+  it('returns false for unknown platform id', () => {
+    expect(isSupportedPlatform('unknown-platform')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isSupportedPlatform('')).toBe(false);
+  });
+
+  it('returns false for near-miss platform names', () => {
+    expect(isSupportedPlatform('Github')).toBe(false);
+    expect(isSupportedPlatform('GITHUB')).toBe(false);
+    expect(isSupportedPlatform('git hub')).toBe(false);
+  });
+
+  it('returns a boolean value (not truthy/falsy)', () => {
+    expect(typeof isSupportedPlatform('github')).toBe('boolean');
+    expect(typeof isSupportedPlatform('nope')).toBe('boolean');
+  });
+});

--- a/packages/shared/src/platforms.ts
+++ b/packages/shared/src/platforms.ts
@@ -292,3 +292,8 @@ export function getDeepLinkUrl(platformId: string, username: string): string | n
   if (!platform?.deepLinkPattern) return null;
   return platform.deepLinkPattern.replace(/{username}/g, username);
 }
+
+/** Returns true if the given ID corresponds to a known platform */
+export function isSupportedPlatform(id: string): boolean {
+  return PLATFORMS[id] !== undefined;
+}


### PR DESCRIPTION
## Summary

Adds a new helper function `isSupportedPlatform(id: string): boolean` to `packages/shared/src/platforms.ts` and adds unit tests for supported and unsupported platform IDs.

Closes #9

---

## Type of Change

* [x] New feature
* [x] Tests only

---

## What Changed

* Added `isSupportedPlatform(id: string): boolean` to `packages/shared/src/platforms.ts`
* Uses `PLATFORMS[id] !== undefined` for safe platform existence checks
* Added test coverage in `packages/shared/src/__tests__/platforms.test.ts`
* Added tests for:

  * valid platform IDs (`github`, `linkedin`, `twitter`, `discord`, `email`)
  * invalid/unknown platform IDs
  * strict boolean return behavior

---

## How to Test

1. Install dependencies

```bash id="njlwmj"
pnpm install
```

2. Run shared package tests

```bash id="xfzy7i"
pnpm --filter @devcard/shared test
```

3. Verify all tests pass successfully

---

## Checklist

* [ ] My code follows the project's coding style (`pnpm -r run lint` passes).
* [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
* [x] I have added or updated tests for the changes I made.
* [x] All tests pass locally (`pnpm -r run test`).
* [ ] I have updated documentation where necessary.
* [x] No new `console.log` or debug statements left in the code.
* [x] Breaking changes are documented in this PR description.

---

## Additional Context

ScreenShots

for unit test proof 

<img width="1501" height="700" alt="Test-passed" src="https://github.com/user-attachments/assets/e5243071-21ee-48cd-967d-b696a59d8cf7" />

for typeCheck proof
<img width="889" height="266" alt="Typescript-check" src="https://github.com/user-attachments/assets/88755fde-37b1-4bab-9198-75b368f92585" />

for eslint

Existing repository lint configuration issue (`eslint` missing in shared package) is pre-existing and unrelated to this PR.


* This is a minimal, low-risk additive helper function.
* Shared package tests pass successfully.

