### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported Versions
+
+The following versions of **DevCard** are currently supported with security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| main    | ✅ Yes             |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in **DevCard**, please **do not open a public issue**.
+
+Instead, report it responsibly by:
+
+- 📧 Opening a [GitHub Private Security Advisory](https://github.com/Dev-Card/DevCard/security/advisories/new)
+- Or reaching out to the maintainer directly via their [GitHub profile](https://github.com/Dev-Card)
+
+### What to include in your report:
+- A clear description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact assessment
+- Any suggested fix (optional but appreciated)
+
+## Response Timeline
+
+| Action                        | Timeframe         |
+| ----------------------------- | ----------------- |
+| Acknowledgement of report     | Within 48 hours   |
+| Status update                 | Within 7 days     |
+| Patch / fix release           | Within 30 days    |
+
+## Responsible Disclosure
+
+We follow a **responsible disclosure** policy. Please give us adequate time to patch the issue before any public disclosure. We deeply appreciate security researchers who help keep **DevCard** safe. 🙏
+
+## References
+
+- [DevCard Repository](https://github.com/Dev-Card/DevCard)
+- [GitHub Security Advisories](https://docs.github.com/en/code-security/security-advisories)
+- [Adding a Security Policy to your repo](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,8 +14,8 @@ If you discover a security vulnerability in **DevCard**, please **do not open a 
 
 Instead, report it responsibly by:
 
-- 📧 Opening a [GitHub Private Security Advisory](https://github.com/Dev-Card/DevCard/security/advisories/new)
-- Or reaching out to the maintainer directly via their [GitHub profile](https://github.com/Dev-Card)
+- 📧 Reaching out to the maintainer directly via their [GitHub profile](https://github.com/Dev-Card)
+- 💬 Sending a private message through GitHub's messaging or social links listed in the profile
 
 ### What to include in your report:
 - A clear description of the vulnerability


### PR DESCRIPTION
## Summary
This PR adds a `SECURITY.md` file to the repository root. DevCard currently has no security policy defined, leaving contributors and users with no safe, private channel to report vulnerabilities. This change establishes a responsible disclosure process in line with GitHub's recommended best practices.

Closes #293

---

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [x] Documentation
- [ ] Infrastructure / DevOps
- [x] Security

---

## What Changed
- Added `SECURITY.md` at the root of the repository
- Defined supported versions with a version support table
- Added vulnerability reporting instructions via the maintainer's GitHub profile
- Included a clear response timeline for reported vulnerabilities
- Outlined a responsible disclosure policy

---

## How to Test
1. Navigate to the repository root and confirm `SECURITY.md` exists
2. Open the file and verify all sections render correctly on GitHub
3. Visit the **Security** tab on GitHub — the policy should now be detected and displayed automatically

---

## Checklist
- [x] My code follows the project's coding style (`pnpm -r run lint` passes).
- [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [ ] I have added or updated tests for the changes I made.
- [x] All tests pass locally (`pnpm -r run test`).
- [x] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [x] Breaking changes are documented in this PR description.

---

## Screenshots / Recordings
Not applicable — documentation-only change with no visual impact.
