### PR TITLE
fix: encode dynamic URL parameters in NFC payload generation

### DIFF
--- a/apps/backend/src/routes/nfc.ts
+++ b/apps/backend/src/routes/nfc.ts
@@ -84,10 +84,10 @@ export async function nfcRoutes(app: FastifyInstance) {
         }
       }
 
-      const payloadUrl = `https://dev-card.vercel.app/${username}${
-        cardId ? `?card=${cardId}` : ''
-      }`;
-
+const safeUsername = encodeURIComponent(username);
+const payloadUrl = `https://dev-card.vercel.app/${safeUsername}${
+  cardId ? `?card=${encodeURIComponent(cardId)}` : ''
+}`;
       const response: NfcPayloadResponse = {
         type: 'URI',
         payload: payloadUrl,


### PR DESCRIPTION
Closes #263

**Changes:**
- Added `encodeURIComponent()` for username and cardId before constructing NFC payload URL
- Prevents malformed URLs when usernames/card IDs contain special characters like `#`, `&`, `?`, spaces
- Ensures consistent NFC payload URL parsing across all NFC readers and scanners