### PR TITLE
fix(web): resolve return home button overlapping on profile not found…

### DIFF
--- a/apps/web/src/routes/u/[username]/+page.svelte
+++ b/apps/web/src/routes/u/[username]/+page.svelte
@@ -410,10 +410,40 @@
   }
 
   .error-glass {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     text-align: center;
-    padding: 3rem;
+    padding: clamp(2.5rem, 5vw, 4rem) clamp(1.5rem, 4vw, 3rem);
     border-radius: var(--radius-xl);
     width: min(100%, 520px);
+  }
+
+  .error-emoji {
+    font-size: clamp(3rem, 7vw, 4.5rem);
+    margin-bottom: 0.5rem;
+    animation: float 3s ease-in-out infinite;
+  }
+
+  .error-glass h1 {
+    font-size: clamp(1.75rem, 4vw, 2.25rem);
+    font-weight: 800;
+    margin-bottom: 0.5rem;
+    color: var(--text-primary);
+  }
+
+  .error-glass p {
+    color: var(--text-muted);
+    font-size: clamp(0.95rem, 2vw, 1.05rem);
+    line-height: 1.6;
+    margin-bottom: 1.75rem;
+    max-width: 340px;
+  }
+
+  @keyframes float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-10px); }
   }
 
   @media (max-width: 720px) {


### PR DESCRIPTION
## Summary

This PR addresses and resolves the spacing and layout issue on the **Profile Not Found** error page, where the "Return Home" button was overlapping or appearing too compressed relative to the paragraph text above it. By introducing a structured Flexbox layout, responsive typography, and optimal margins to the `.error-glass` container and its descendants, the error page is now visually polished, balanced, and responsive across all screen sizes.

Closes #242

---

## Type of Change

- [x] Bug fix
- [x] UI / Design change

---

## What Changed

- **[`apps/web/src/routes/u/[username]/+page.svelte`](file:///apps/web/src/routes/u/[username]/+page.svelte)**:
  - Enabled Flexbox on the `.error-glass` class (`flex-direction: column`, `align-items: center`, `justify-content: center`) for proper vertical alignment of all elements.
  - Implemented responsive padding using `clamp()` (`clamp(2.5rem, 5vw, 4rem) clamp(1.5rem, 4vw, 3rem)`) for beautiful spacing on desktop and mobile.
  - Styled `.error-emoji` with responsive size (`clamp(3rem, 7vw, 4.5rem)`) and added a premium float micro-animation.
  - Configured responsive headers (`.error-glass h1`) and descriptions (`.error-glass p`) with proper line heights, colors, and margins.
  - Added a clean `1.75rem` margin below the paragraph to ensure the "Return Home" button (`.btn-primary`) never overlaps with the text and has robust visual distinction.

---

## How to Test

To verify the visual changes:
1. Start the web application locally:
   ```bash
   pnpm web
