### PR TITLE
fix(web): eliminate dark mode white flash on initial page load

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -8,6 +8,22 @@
 		<meta property="og:type" content="website" />
 		<meta property="og:site_name" content="DevCard" />
 		<meta name="twitter:card" content="summary_large_image" />
+		<!-- Blocking theme script: applies dark class before first paint to prevent flash.
+		     Reads saved preference from localStorage, falls back to system preference. -->
+		<script>
+			(function () {
+				try {
+					var saved = localStorage.getItem('devcard-theme');
+					var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+					if (saved === 'dark' || (!saved && prefersDark)) {
+						document.documentElement.classList.add('dark');
+					}
+				} catch (e) {
+					// localStorage unavailable — default to dark
+					document.documentElement.classList.add('dark');
+				}
+			})();
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
## Summary
Eliminates the dark mode white flash on initial page load. Previously, the theme was applied inside `onMount` in `+page.svelte`, which runs after first paint — causing a brief white flash for dark mode users on hard refresh or slow page loads. This PR adds a blocking inline IIFE script to `<head>` in `app.html` that reads `localStorage('devcard-theme')` and falls back to `window.matchMedia('prefers-color-scheme: dark')` to apply the `.dark` class to `<html>` before any content renders.

Closes #91

---

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed
- `apps/web/src/app.html` — Added a blocking synchronous IIFE script in `<head>` that reads `localStorage('devcard-theme')` and falls back to `window.matchMedia('prefers-color-scheme: dark')`, applying `.dark` to `<html>` before first paint. Wrapped in try/catch for private browsing resilience.

---

## How to Test
1. Open the app and set theme to dark using the 🌙 toggle
2. Hard refresh (Cmd+Shift+R) — page should load dark instantly with no white flash
3. Open DevTools → Application → Local Storage → delete `devcard-theme`
4. Hard refresh — should still load dark (system preference fallback)
5. Set `devcard-theme` to `light` in localStorage, hard refresh — should load light with no flash

---

## Checklist
- [x] My code follows the project's coding style (`pnpm -r run lint` passes).
- [ ] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [ ] I have added or updated tests for the changes I made.
- [ ] All tests pass locally (`pnpm -r run test`).
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description.

---

## Screenshots / Recordings

**Light mode (devcard-theme=light):**
<img width="1449" height="840" alt="image" src="https://github.com/user-attachments/assets/5b595db8-ea2c-42e7-bb16-9ee8750ea349" />


**Dark mode (devcard-theme=dark):**
<img width="1449" height="840" alt="image" src="https://github.com/user-attachments/assets/54817838-39a7-43a7-8318-6c7ed54d8918" />

Both load instantly with correct theme — no white flash on hard refresh.

---

## Additional Context
Only `apps/web/src/app.html` was modified. No changes to component logic, styles, or other files. The existing `onMount` theme toggle in `+page.svelte` continues to handle runtime theme switching — this script only ensures the correct initial state is set before first paint.

The backend test failures (`event.test.ts`) are pre-existing and unrelated to this change — they fail identically on `main` without our modification. Our change only touches `apps/web/src/app.html`.