### PR TITLE
fix: linting issues on app.ts. 

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,30 +1,31 @@
-import Fastify from 'fastify';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import cookie from '@fastify/cookie';
 import cors from '@fastify/cors';
 import helmet from '@fastify/helmet';
 import jwt from '@fastify/jwt';
-import cookie from '@fastify/cookie';
 import multipart from '@fastify/multipart';
-import fastifyStatic from '@fastify/static';
 import rateLimit from '@fastify/rate-limit';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import fastifyStatic from '@fastify/static';
+import Fastify, {type FastifyInstance} from 'fastify';
 
 import { prismaPlugin } from './plugins/prisma.js';
 import { redisPlugin } from './plugins/redis.js';
-import { authRoutes } from './routes/auth.js';
-import { profileRoutes } from './routes/profiles.js';
-import { cardRoutes } from './routes/cards.js';
-import { publicRoutes } from './routes/public.js';
-import { followRoutes } from './routes/follow.js';
-import { connectRoutes } from './routes/connect.js';
 import { analyticsRoutes } from './routes/analytics.js';
-import { nfcRoutes } from './routes/nfc.js';
+import { authRoutes } from './routes/auth.js';
+import { cardRoutes } from './routes/cards.js';
+import { connectRoutes } from './routes/connect.js';
 import { eventRoutes } from './routes/event.js';
+import { followRoutes } from './routes/follow.js';
+import { nfcRoutes } from './routes/nfc.js';
+import { profileRoutes } from './routes/profiles.js';
+import { publicRoutes } from './routes/public.js';
 import { validateEnv } from './utils/validateEnv.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export async function buildApp() {
+export async function buildApp():Promise<FastifyInstance> {
   // Validate all required secrets before registering any plugin.
   // If validation fails the process exits here — no partially-initialised
   // auth state can exist because Fastify is not yet instantiated.
@@ -93,7 +94,7 @@ export async function buildApp() {
   app.decorate('authenticate', async function (request: any, reply: any) {
     try {
       await request.jwtVerify();
-    } catch (err) {
+    } catch (_err) {
       reply.status(401).send({ error: 'Unauthorized' });
     }
   });

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -7,8 +7,8 @@ import helmet from '@fastify/helmet';
 import jwt from '@fastify/jwt';
 import multipart from '@fastify/multipart';
 import rateLimit from '@fastify/rate-limit';
-import fastifyStatic from '@fastify/static';
 import Fastify, {type FastifyInstance} from 'fastify';
+import fastifyStatic from '@fastify/static';
 
 import { prismaPlugin } from './plugins/prisma.js';
 import { redisPlugin } from './plugins/redis.js';

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -7,8 +7,8 @@ import helmet from '@fastify/helmet';
 import jwt from '@fastify/jwt';
 import multipart from '@fastify/multipart';
 import rateLimit from '@fastify/rate-limit';
-import Fastify, {type FastifyInstance} from 'fastify';
 import fastifyStatic from '@fastify/static';
+import Fastify, {type FastifyInstance} from 'fastify';
 
 import { prismaPlugin } from './plugins/prisma.js';
 import { redisPlugin } from './plugins/redis.js';


### PR DESCRIPTION
## Summary

Fixes backend lint issues in `app.ts` by adding an explicit return type to `buildApp()` and resolving the unused caught error variable inside the authentication decorator. This keeps the codebase aligned with the project's ESLint rules and improves type safety.

Closes #

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- Added `FastifyInstance` return type to `buildApp()` to satisfy `@typescript-eslint/explicit-function-return-type`.
- Renamed unused caught error variable from `err` to `_err` inside `authenticate` decorator to satisfy `@typescript-eslint/no-unused-vars`.
- Fixed backend lint warnings/errors to ensure cleaner and more consistent TypeScript code.

---

## How to Test

1. Run lint checks:

```bash
pnpm -r run lint
```

2. Confirm no lint errors remain in `apps/backend/src/app.ts`.

3. Start the backend and verify authentication and health routes continue working as expected.

---

## Checklist

- [x] My code follows the project's coding style (`pnpm -r run lint` passes).
- [ ] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [ ] I have added or updated tests for the changes I made.
- [ ] All tests pass locally (`pnpm -r run test`).
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description.

---

## Additional Context

This change is lint and type-safety focused and does not introduce functional behavior changes.