### PR TITLE
fix: add noreferrer to external GitHub link

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -63,7 +63,7 @@
         href="https://github.com/Dev-Card/DevCard"
         class="btn-primary"
         target="_blank"
-        rel="noopener"
+        rel="noopener noreferrer"
       >
         ⭐ Star on GitHub
       </a>


### PR DESCRIPTION
## Summary

Adds the missing `noreferrer` value to an external GitHub link opened with `target="_blank"` in the landing page.

Closes #262 

---

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor (no functional change)
* [ ] UI / Design change
* [ ] Tests only
* [ ] Documentation
* [ ] Infrastructure / DevOps
* [x] Security

---

## What Changed

* Updated the external GitHub link in `apps/web/src/routes/+page.svelte`
* Added `rel="noreferrer"` alongside `noopener`
* Improved external link security best practices for links opened in new tabs

---

## How to Test

1. Run the application locally using `pnpm dev`
2. Open the landing page
3. Click the GitHub button and verify it opens securely in a new tab

---

## Checklist

* [x] My code follows the project's coding style (`pnpm -r run lint` passes).
* [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
* [ ] I have added or updated tests for the changes I made.
* [ ] All tests pass locally (`pnpm -r run test`).
* [ ] I have updated documentation where necessary.
* [x] No new `console.log` or debug statements left in the code.
* [ ] Breaking changes are documented in this PR description.

---

## Additional Context

This PR addresses a remaining external link that used `target="_blank"` without the complete recommended `rel="noopener noreferrer"` configuration.