### PR TITLE
feat(mobile): implement NFC tag writing support to share DevCards

### DIFF
--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.NFC" />
+    <uses-feature android:name="android.hardware.nfc" android:required="false" />
+
+    <application
+      android:name=".MainApplication"
+      android:label="@string/app_name"
+      android:icon="@mipmap/ic_launcher"
+      android:roundIcon="@mipmap/ic_launcher_round"
+      android:allowBackup="false"
+      android:theme="@style/AppTheme"
+      android:supportsRtl="true">
+      <activity
+        android:name=".MainActivity"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize|uiMode"
+        android:launchMode="singleTask"
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">
+        <intent-filter>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.LAUNCHER" />
+        </intent-filter>
+      </activity>
+    </application>
+</manifest>

--- a/apps/mobile/ios/DevCard/Info.plist
+++ b/apps/mobile/ios/DevCard/Info.plist
@@ -36,6 +36,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NFCReaderUsageDescription</key>
+	<string>DevCard needs NFC to write your profile link to your physical card.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "^2.28.0",
+    "react-native-nfc-manager": "^3.14.12",
     "react-native-qrcode-svg": "^6.3.0",
     "react-native-reanimated": "^4.1.7",
     "react-native-safe-area-context": "^5.6.2",

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -15,8 +15,7 @@ import { useNavigation } from '@react-navigation/native';
 import { COLORS, SPACING, FONT_SIZE, BORDER_RADIUS } from '../theme/tokens';
 import { useAuth } from '../context/AuthContext';
 import { API_BASE_URL } from '../config';
-
-import { useNavigation } from '@react-navigation/native';
+import NfcManager, { Ndef, NfcTech } from 'react-native-nfc-manager';
 
 export default function SettingsScreen() {
   const navigation = useNavigation<any>();
@@ -27,6 +26,51 @@ export default function SettingsScreen() {
   const [role, setRole] = useState(user?.role || '');
   const [company, setCompany] = useState(user?.company || '');
   const [saving, setSaving] = useState(false);
+  const [writingNfc, setWritingNfc] = useState(false);
+
+  const writeNfcTag = async () => {
+    try {
+      const supported = await NfcManager.isSupported();
+      if (!supported) {
+        Alert.alert('Error', 'NFC is not supported on this device');
+        return;
+      }
+
+      setWritingNfc(true);
+      await NfcManager.start();
+
+      const res = await fetch(`${API_BASE_URL}/api/nfc/payload`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      
+      if (!res.ok) {
+        throw new Error('Failed to fetch NFC payload');
+      }
+      
+      const data = await res.json();
+      if (!data.payload) {
+        throw new Error('Invalid payload received');
+      }
+
+      Alert.alert('NFC', 'Hold your phone near an NFC tag');
+      await NfcManager.requestTechnology(NfcTech.Ndef);
+      
+      const bytes = Ndef.encodeMessage([
+        Ndef.uriRecord(data.payload),
+      ]);
+      
+      if (bytes) {
+        await NfcManager.ndefHandler.writeNdefMessage(bytes);
+        Alert.alert('Success', 'Successfully wrote DevCard to NFC tag!');
+      }
+    } catch (ex: any) {
+      console.warn(ex);
+      Alert.alert('Error', ex.message || 'Failed to write NFC tag. Please try again.');
+    } finally {
+      NfcManager.cancelTechnologyRequest();
+      setWritingNfc(false);
+    }
+  };
 
   const handleSave = async () => {
     setSaving(true);
@@ -113,6 +157,23 @@ export default function SettingsScreen() {
             <View style={styles.settingRowLeft}>
               <Text style={styles.settingRowIcon}>🔌</Text>
               <Text style={styles.settingRowText}>Connected Platforms</Text>
+            </View>
+            <Text style={styles.settingRowArrow}>→</Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* Physical Cards */}
+        <View style={styles.sectionContainer}>
+          <Text style={styles.sectionSubtitle}>Physical Cards</Text>
+          <TouchableOpacity
+            style={styles.settingRow}
+            onPress={writeNfcTag}
+            disabled={writingNfc}>
+            <View style={styles.settingRowLeft}>
+              <Text style={styles.settingRowIcon}>💳</Text>
+              <Text style={styles.settingRowText}>
+                {writingNfc ? 'Writing to NFC...' : 'Write to NFC Card'}
+              </Text>
             </View>
             <Text style={styles.settingRowArrow}>→</Text>
           </TouchableOpacity>


### PR DESCRIPTION
## Description
This PR introduces the ability to write a DevCard profile link directly to a physical NFC tag, enabling a seamless one-tap sharing experience on the mobile app.

Fixes #347

## Changes Included
- **Dependencies**: Added `react-native-nfc-manager` to `@devcard/mobile` to handle cross-platform NFC interactions.
- **Permissions**: Configured necessary NFC permissions for both iOS (`NFCReaderUsageDescription` in `Info.plist`) and Android (`android.permission.NFC` in `AndroidManifest.xml`).
- **UI & Functionality**: 
  - Added a "Physical Cards" section to the `SettingsScreen`.
  - Added a "Write to NFC Card" button that securely fetches the user's NDEF URI payload from the existing `/api/nfc/payload` backend endpoint.
  - Interfaced with `NfcManager` to write the fetched URI record securely to a scanned physical NFC tag.

## Testing Instructions
1. Run `pnpm install` from the repository root to ensure the new `react-native-nfc-manager` dependency is linked.
2. Ensure you have physical devices connected, as NFC emulation does not behave reliably on standard simulators.
3. Build and run the app on Android (`pnpm --filter @devcard/mobile run android`) or iOS (`pnpm --filter @devcard/mobile run ios`).
4. Navigate to the **Settings** screen.
5. Tap **"Write to NFC Card"** under the "Physical Cards" section.
6. Hold your device near a writable NFC tag when prompted.
7. Verify that tapping the successfully written NFC tag with any smartphone opens the DevCard profile in the default web browser.
