### PR TITLE
fix: remove unauthenticated public upload access

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -76,12 +76,8 @@ export async function buildApp():Promise<FastifyInstance> {
     timeWindow: '1 minute',
   });
 
-  // Static file serving for uploads
-  await app.register(fastifyStatic, {
-    root: path.join(__dirname, '..', 'uploads'),
-    prefix: '/uploads/',
-    decorateReply: false,
-  });
+// Files must be served through authenticated route handlers
+// with ownership validation.
 
   // ─── Database & Cache Plugins ───
  if (process.env.NODE_ENV !== 'test') {


### PR DESCRIPTION
## Summary

Removed public static serving for `/uploads/` to prevent unauthenticated access to uploaded files.

Previously, uploaded files could be accessed directly without authentication or ownership validation.

Closes #334

## Type of Change

- [x] Bug fix
- [x] Security fix

## Changes Made

- Removed public `fastifyStatic` registration for uploads
- Prevented direct public access to uploaded files
- Added security comments documenting expected authenticated access flow