### PR TITLE
test(public): add regression coverage for public route registration

### DIFF
--- a/apps/backend/src/__tests__/public.test.ts
+++ b/apps/backend/src/__tests__/public.test.ts
@@ -38,7 +38,9 @@ const mockPrisma = {
   followLog: {
     findMany: vi.fn().mockResolvedValue([]),
   },
-  card: {} as any,
+  card: {
+    findFirst: vi.fn(),
+  },
 };
 
 async function buildApp() {
@@ -54,6 +56,69 @@ async function buildApp() {
 }
 
 // ─── QR size validation ───────────────────────────────────────────────────────
+
+describe('Public profile routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (generateQRBuffer as ReturnType<typeof vi.fn>).mockResolvedValue(Buffer.from('fake-png'));
+    (generateQRSvg as ReturnType<typeof vi.fn>).mockResolvedValue('<svg>fake</svg>');
+  });
+
+  it('returns 200 for GET /:username without runtime route registration errors', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/public/testuser',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      username: 'testuser',
+      displayName: 'Test User',
+      links: [],
+    });
+  });
+
+  it('returns 200 for GET /:username/card/:cardId without runtime route registration errors', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+    mockPrisma.card.findFirst.mockResolvedValue({
+      id: 'card-123',
+      title: 'Main Card',
+      cardLinks: [],
+    });
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/public/testuser/card/card-123',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({
+      title: 'Main Card',
+      owner: {
+        username: 'testuser',
+        displayName: 'Test User',
+      },
+      links: [],
+    });
+  });
+
+  it('keeps QR endpoint working', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(mockUser);
+
+    const app = await buildApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/public/testuser/qr?size=400',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/image\/png/);
+  });
+});
 
 describe('GET /api/public/:username/qr — size validation', () => {
   beforeEach(() => {


### PR DESCRIPTION
Closes #309

## Summary

Adds focused regression coverage for the public profile routes involved in #309 to ensure runtime Fastify route-registration failures do not reappear.

The underlying implementation in `apps/backend/src/routes/public.ts` is already fixed on latest upstream/main, so this PR intentionally avoids modifying route logic and instead protects against future regressions through targeted test coverage.

Covered routes:

- GET `/api/public/:username`
- GET `/api/public/:username/card/:cardId`
- GET `/api/public/:username/qr`

## Tests Added

Added focused regression tests verifying:

- public profile route returns `200 OK`
- public shared-card route returns `200 OK`
- routes do not trigger runtime Fastify registration errors
- QR endpoint behavior remains unchanged

## Notes

- No API contract changes
- No route implementation changes
- No unrelated refactors
- Only focused regression coverage added for the already-fixed production issue

## Verification

```bash
node_modules\.bin\vitest.CMD run src\__tests__\public.test.ts