### PR TITLE
feat: skeleton loaders for public DevCard pages — shimmer animation, fade transitions & reduced-motion support

### DIFF
--- a/apps/web/src/lib/components/DevCardSkeleton.svelte
+++ b/apps/web/src/lib/components/DevCardSkeleton.svelte
@@ -1,0 +1,190 @@
+<script lang="ts">
+	import SkeletonBlock from './SkeletonBlock.svelte';
+
+	let { linkCount = 3 }: { linkCount?: number } = $props();
+</script>
+
+<div class="card-wrapper" aria-hidden="true">
+	<div class="premium-card skeleton-premium">
+		<div class="card-glass"></div>
+
+		<div class="card-top">
+			<div class="brand-row">
+				<SkeletonBlock style="width: 40px; height: 24px;" rounded="8px" />
+				<SkeletonBlock style="width: 82px; height: 0.75rem;" />
+			</div>
+			<SkeletonBlock style="width: 24px; height: 24px; opacity: 0.35;" rounded="6px" />
+		</div>
+
+		<div class="card-mid">
+			<SkeletonBlock class="avatar-skeleton" style="width: 92px; height: 92px; flex-shrink: 0;" rounded="28px" />
+			<div class="main-info">
+				<SkeletonBlock style="width: 62%; height: 2.2rem; margin-bottom: 0.65rem;" />
+				<SkeletonBlock style="width: 48%; height: 0.9rem; margin-bottom: 0.45rem;" />
+				<SkeletonBlock style="width: 26%; height: 0.8rem; opacity: 0.6;" />
+			</div>
+		</div>
+
+		<div class="card-bottom">
+			<div class="bio-lines">
+				<SkeletonBlock style="width: 90%; height: 0.85rem;" />
+				<SkeletonBlock style="width: 66%; height: 0.85rem;" />
+			</div>
+			<SkeletonBlock style="width: 82px; height: 36px;" rounded="14px" />
+		</div>
+	</div>
+
+	<div class="action-section">
+		<SkeletonBlock style="width: 104px; height: 0.75rem; margin-bottom: 0.85rem;" />
+		<div class="platform-grid">
+			{#each Array(linkCount) as _}
+				<div class="platform-tile skeleton-tile">
+					<SkeletonBlock style="width: 44px; height: 44px; flex-shrink: 0;" rounded="16px" />
+					<div class="tile-copy">
+						<SkeletonBlock style="width: 42%; height: 0.9rem;" />
+						<SkeletonBlock style="width: 30%; height: 0.75rem; opacity: 0.6;" />
+					</div>
+				</div>
+			{/each}
+		</div>
+	</div>
+
+	<footer class="footer">
+		<SkeletonBlock style="width: 144px; height: 0.85rem; margin: 0 auto; opacity: 0.55;" />
+	</footer>
+</div>
+
+<style>
+	.card-wrapper {
+		width: 100%;
+		max-width: 560px;
+		display: flex;
+		flex-direction: column;
+		gap: 1.75rem;
+	}
+
+	.premium-card {
+		background: rgba(15, 23, 42, 0.96);
+		border-radius: 32px;
+		padding: 34px;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		position: relative;
+		overflow: hidden;
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		box-shadow: 0 32px 80px -28px rgba(0, 0, 0, 0.65);
+		min-height: 520px;
+		pointer-events: none;
+	}
+
+	.card-glass {
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(135deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0.02) 100%);
+		pointer-events: none;
+	}
+
+	.card-top,
+	.card-mid,
+	.card-bottom {
+		position: relative;
+		z-index: 1;
+	}
+
+	.card-top,
+	.brand-row,
+	.card-mid,
+	.platform-tile {
+		display: flex;
+		align-items: center;
+	}
+
+	.card-top {
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.brand-row {
+		gap: 0.85rem;
+	}
+
+	.card-mid {
+		gap: 22px;
+		margin-top: 1.75rem;
+	}
+
+	.main-info {
+		width: 100%;
+		min-width: 0;
+	}
+
+	.card-bottom {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-end;
+		gap: 1rem;
+		margin-top: 2rem;
+		flex-wrap: wrap;
+	}
+
+	.bio-lines {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 0.45rem;
+		min-width: 180px;
+	}
+
+	.platform-grid {
+		display: flex;
+		flex-direction: column;
+		gap: 0.95rem;
+	}
+
+	.platform-tile {
+		width: 100%;
+		border-radius: 20px;
+		padding: 16px;
+		background: rgba(255, 255, 255, 0.06);
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		pointer-events: none;
+	}
+
+	.tile-copy {
+		flex: 1;
+		margin-left: 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		min-width: 0;
+	}
+
+	.footer {
+		text-align: center;
+		margin-top: 24px;
+	}
+
+	@media (max-width: 780px) {
+		.card-wrapper {
+			max-width: 100%;
+		}
+
+		.premium-card {
+			min-height: auto;
+			padding: 28px;
+		}
+
+		.card-mid,
+		.card-bottom {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+	}
+
+	@media (max-width: 560px) {
+		.platform-tile {
+			padding: 14px;
+		}
+	}
+</style>

--- a/apps/web/src/lib/components/ProfileSkeleton.svelte
+++ b/apps/web/src/lib/components/ProfileSkeleton.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+	import SkeletonBlock from './SkeletonBlock.svelte';
+
+	let { linkCount = 3 }: { linkCount?: number } = $props();
+</script>
+
+<div class="profile-container" aria-hidden="true">
+	<div class="profile-card glass skeleton-card">
+		<header class="profile-header">
+			<div class="avatar-wrapper">
+				<SkeletonBlock class="avatar-skeleton" style="width: 100%; height: 100%;" rounded="32% 68% 63% 37% / 34% 36% 64% 66%" />
+			</div>
+			<SkeletonBlock style="width: 55%; height: 2rem; margin: 0 auto 0.75rem;" />
+			<SkeletonBlock style="width: 38%; height: 1.1rem; margin: 0 auto 1rem;" rounded="999px" />
+			<SkeletonBlock style="width: 80%; height: 0.9rem; margin: 0 auto 0.55rem;" />
+			<SkeletonBlock style="width: 55%; height: 0.9rem; margin: 0 auto;" />
+		</header>
+
+		<div class="links-grid">
+			{#each Array(linkCount) as _}
+				<div class="link-tile skeleton-tile">
+					<SkeletonBlock style="width: 46px; height: 46px; flex-shrink: 0;" rounded="15px" />
+					<div class="tile-copy">
+						<SkeletonBlock style="width: 45%; height: 0.9rem;" />
+						<SkeletonBlock style="width: 30%; height: 0.75rem; opacity: 0.6;" />
+					</div>
+				</div>
+			{/each}
+		</div>
+
+		<footer class="card-footer">
+			<SkeletonBlock style="width: 112px; height: 0.75rem;" />
+			<SkeletonBlock style="width: 72px; height: 0.75rem;" />
+		</footer>
+	</div>
+</div>
+
+<style>
+	.profile-container {
+		min-height: 100vh;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		padding: clamp(2rem, 6vw, 5rem) 1.25rem 3rem;
+	}
+
+	.profile-card {
+		width: 100%;
+		max-width: 540px;
+		border-radius: var(--radius-xl);
+		padding: 2.5rem 2rem;
+		box-shadow: 0 26px 60px -20px rgba(0, 0, 0, 0.55);
+		position: relative;
+		overflow: hidden;
+		border: 1px solid rgba(255, 255, 255, 0.08);
+		background: rgba(15, 23, 42, 0.96);
+		pointer-events: none;
+	}
+
+	.profile-header {
+		text-align: center;
+		margin-bottom: 2.5rem;
+	}
+
+	.avatar-wrapper {
+		position: relative;
+		width: 120px;
+		height: 120px;
+		margin: 0 auto 1.75rem;
+	}
+
+	.links-grid {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.link-tile {
+		display: flex;
+		align-items: center;
+		padding: 1rem;
+		border-radius: calc(var(--radius) * 1.1);
+		border: 1px solid rgba(255, 255, 255, 0.1);
+		background: rgba(255, 255, 255, 0.06);
+		box-shadow: 0 12px 30px -18px rgba(0, 0, 0, 0.35);
+	}
+
+	.tile-copy {
+		flex: 1;
+		margin-left: 1.1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.45rem;
+		min-width: 0;
+	}
+
+	.card-footer {
+		margin-top: 2.5rem;
+		padding-top: 1.75rem;
+		border-top: 1px solid rgba(255, 255, 255, 0.08);
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+		flex-wrap: wrap;
+		opacity: 0.55;
+	}
+
+	@media (max-width: 720px) {
+		.profile-card {
+			padding: 2rem 1.5rem;
+		}
+
+		.profile-header {
+			margin-bottom: 2rem;
+		}
+
+		.avatar-wrapper {
+			width: 108px;
+			height: 108px;
+			margin-bottom: 1.5rem;
+		}
+
+		.card-footer {
+			flex-direction: column;
+			align-items: flex-start;
+		}
+	}
+
+	@media (max-width: 520px) {
+		.profile-container {
+			padding: 2rem 1rem 2.5rem;
+		}
+
+		.link-tile {
+			padding: 0.95rem;
+		}
+
+		.tile-copy {
+			margin-left: 0.9rem;
+		}
+	}
+</style>

--- a/apps/web/src/lib/components/SkeletonBlock.svelte
+++ b/apps/web/src/lib/components/SkeletonBlock.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	let {
+		class: className = '',
+		style = '',
+		rounded = '8px'
+	}: {
+		class?: string;
+		style?: string;
+		rounded?: string;
+	} = $props();
+</script>
+
+<span
+	class={`skeleton-block ${className}`.trim()}
+	style={`border-radius: ${rounded}; ${style}`}
+	aria-hidden="true"
+></span>
+
+<style>
+	@keyframes skeleton-shimmer {
+		0% {
+			background-position: -200% center;
+		}
+
+		100% {
+			background-position: 200% center;
+		}
+	}
+
+	.skeleton-block {
+		display: block;
+		background: linear-gradient(
+			90deg,
+			rgba(255, 255, 255, 0.06) 25%,
+			rgba(255, 255, 255, 0.14) 50%,
+			rgba(255, 255, 255, 0.06) 75%
+		);
+		background-size: 200% 100%;
+		animation: skeleton-shimmer 1.55s ease-in-out infinite;
+		box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.skeleton-block {
+			animation: none;
+			background-position: center;
+		}
+	}
+</style>

--- a/apps/web/src/routes/devcard/[id]/+page.svelte
+++ b/apps/web/src/routes/devcard/[id]/+page.svelte
@@ -1,6 +1,27 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
+	import DevCardSkeleton from '$lib/components/DevCardSkeleton.svelte';
+
 	let { data } = $props();
 	const card = $derived(data.card);
+	const skeletonTileCount = $derived(Math.min(Math.max(card.links?.length || 3, 3), 5));
+
+	let mounted = $state(false);
+	let showSkeleton = $state(true);
+
+	onMount(() => {
+		const frame = requestAnimationFrame(() => {
+			mounted = true;
+		});
+		const timer = setTimeout(() => {
+			showSkeleton = false;
+		}, 360);
+
+		return () => {
+			cancelAnimationFrame(frame);
+			clearTimeout(timer);
+		};
+	});
 
 	function getPlatformColor(platform: string) {
 		const colors: Record<string, string> = {
@@ -15,8 +36,8 @@
 		return colors[platform.toLowerCase()] || '#6366F1';
 	}
 
-	function handlePlatformClick(link: any) {
-		window.open(link.url, '_blank');
+	function handlePlatformClick(link: { url: string }) {
+		window.open(link.url, '_blank', 'noopener,noreferrer');
 	}
 </script>
 
@@ -26,78 +47,84 @@
 </svelte:head>
 
 <div class="page-container">
-	<div class="card-wrapper">
-		<!-- Premium Obsidian Card -->
-		<div class="premium-card">
-			<div class="card-glass"></div>
-			
-			<div class="card-top">
-				<div class="brand-row">
-					<div class="mini-chip"></div>
-					<span class="brand-text">DevCard PRO</span>
+	<div class="card-stage">
+		{#if showSkeleton}
+			<div class="loading-layer" class:exiting={mounted}>
+				<DevCardSkeleton linkCount={skeletonTileCount} />
+			</div>
+		{/if}
+
+		<div class="card-wrapper real-card {mounted ? 'loaded' : 'pre-load'}">
+			<div class="premium-card">
+				<div class="card-glass"></div>
+
+				<div class="card-top">
+					<div class="brand-row">
+						<div class="mini-chip"></div>
+						<span class="brand-text">DevCard PRO</span>
+					</div>
+					<span class="contactless">NFC</span>
 				</div>
-				<span class="contactless">📶</span>
+
+				<div class="card-mid">
+					<div class="avatar-container">
+						{#if card.owner.avatarUrl}
+							<img src={card.owner.avatarUrl} alt={card.owner.displayName} class="avatar" />
+						{:else}
+							<div class="avatar-placeholder" style="background: {card.owner.accentColor || '#6366F1'}">
+								{card.owner.displayName.charAt(0).toUpperCase()}
+							</div>
+						{/if}
+					</div>
+					<div class="main-info">
+						<h1>{card.owner.displayName}</h1>
+						<p class="role">
+							{card.owner.role || 'Developer'}{card.owner.company ? ` @ ${card.owner.company}` : ''}
+						</p>
+						{#if card.owner.pronouns}
+							<p class="pronouns">{card.owner.pronouns}</p>
+						{/if}
+					</div>
+				</div>
+
+				<div class="card-bottom">
+					<div class="bio-container">
+						{#if card.owner.bio}
+							<p class="bio-text">{card.owner.bio}</p>
+						{/if}
+					</div>
+					<div class="card-badge">
+						<span>PLATINUM</span>
+					</div>
+				</div>
 			</div>
 
-			<div class="card-mid">
-				<div class="avatar-container">
-					{#if card.owner.avatarUrl}
-						<img src={card.owner.avatarUrl} alt={card.owner.displayName} class="avatar" />
-					{:else}
-						<div class="avatar-placeholder" style="background: {card.owner.accentColor || '#6366F1'}">
-							{card.owner.displayName.charAt(0).toUpperCase()}
-						</div>
-					{/if}
-				</div>
-				<div class="main-info">
-					<h1>{card.owner.displayName}</h1>
-					<p class="role">
-						{card.owner.role || 'Developer'}{card.owner.company ? ` @ ${card.owner.company}` : ''}
-					</p>
-					{#if card.owner.pronouns}
-						<p class="pronouns">{card.owner.pronouns}</p>
-					{/if}
+			<div class="action-section">
+				<h2>Connections</h2>
+				<div class="platform-grid">
+					{#each card.links as link}
+						<button
+							class="platform-tile"
+							onclick={() => handlePlatformClick(link)}
+							style="--brand-color: {getPlatformColor(link.platform)}"
+						>
+							<div class="tile-icon">
+								{link.platform.charAt(0).toUpperCase()}
+							</div>
+							<div class="tile-info">
+								<span class="platform-name">{link.platform}</span>
+								<span class="username">@{link.username}</span>
+							</div>
+							<div class="tile-arrow">&rarr;</div>
+						</button>
+					{/each}
 				</div>
 			</div>
 
-			<div class="card-bottom">
-				<div class="bio-container">
-					{#if card.owner.bio}
-						<p class="bio-text">{card.owner.bio}</p>
-					{/if}
-				</div>
-				<div class="card-badge">
-					<span>PLATINUM</span>
-				</div>
-			</div>
+			<footer class="footer">
+				<p>Powered by <a href="/">DevCard</a> &#9889;</p>
+			</footer>
 		</div>
-
-		<!-- Action Section -->
-		<div class="action-section">
-			<h2>Connections</h2>
-			<div class="platform-grid">
-				{#each card.links as link}
-					<button 
-						class="platform-tile" 
-						onclick={() => handlePlatformClick(link)}
-						style="--brand-color: {getPlatformColor(link.platform)}"
-					>
-						<div class="tile-icon">
-							{link.platform.charAt(0).toUpperCase()}
-						</div>
-						<div class="tile-info">
-							<span class="platform-name">{link.platform}</span>
-							<span class="username">@{link.username}</span>
-						</div>
-						<div class="tile-arrow">→</div>
-					</button>
-				{/each}
-			</div>
-		</div>
-		
-		<footer class="footer">
-			<p>Powered by <a href="/">DevCard</a> ⚡</p>
-		</footer>
 	</div>
 </div>
 
@@ -116,6 +143,24 @@
 		padding: clamp(2rem, 6vw, 4rem) 1.25rem;
 	}
 
+	.card-stage {
+		position: relative;
+		width: 100%;
+		max-width: 560px;
+	}
+
+	.loading-layer {
+		position: absolute;
+		inset: 0;
+		z-index: 2;
+		opacity: 1;
+		transition: opacity 0.28s ease;
+	}
+
+	.loading-layer.exiting {
+		opacity: 0;
+	}
+
 	.card-wrapper {
 		width: 100%;
 		max-width: 560px;
@@ -124,7 +169,20 @@
 		gap: 1.75rem;
 	}
 
-	/* Premium Card Styles */
+	.real-card {
+		transition: opacity 0.48s ease, transform 0.48s ease;
+	}
+
+	.real-card.pre-load {
+		opacity: 0;
+		transform: translateY(14px);
+	}
+
+	.real-card.loaded {
+		opacity: 1;
+		transform: translateY(0);
+	}
+
 	.premium-card {
 		background: rgba(15, 23, 42, 0.96);
 		border-radius: 32px;
@@ -176,7 +234,9 @@
 	}
 
 	.contactless {
-		font-size: 22px;
+		font-size: 0.72rem;
+		font-weight: 800;
+		letter-spacing: 0.14em;
 		opacity: 0.35;
 	}
 
@@ -208,11 +268,16 @@
 		background: rgba(99, 102, 241, 0.18);
 	}
 
+	.main-info {
+		min-width: 0;
+	}
+
 	.main-info h1 {
 		margin: 0;
 		font-size: clamp(2.1rem, 4vw, 2.5rem);
 		font-weight: 800;
-		letter-spacing: -0.6px;
+		letter-spacing: 0;
+		overflow-wrap: anywhere;
 	}
 
 	.role {
@@ -244,6 +309,7 @@
 		line-height: 1.75;
 		color: rgba(255, 255, 255, 0.72);
 		max-width: 320px;
+		overflow-wrap: anywhere;
 	}
 
 	.card-badge {
@@ -261,7 +327,6 @@
 		text-transform: uppercase;
 	}
 
-	/* Action Section */
 	h2 {
 		font-size: 0.85rem;
 		text-transform: uppercase;
@@ -312,6 +377,7 @@
 		font-size: 1.05rem;
 		font-weight: 800;
 		box-shadow: 0 10px 20px -12px rgba(0, 0, 0, 0.4);
+		flex-shrink: 0;
 	}
 
 	.tile-info {
@@ -320,19 +386,22 @@
 		display: flex;
 		flex-direction: column;
 		min-width: 0;
+		text-align: left;
 	}
 
 	.platform-name {
 		font-size: 1rem;
 		font-weight: 700;
-		letter-spacing: -0.02em;
+		letter-spacing: 0;
 		color: #f8fafc;
+		overflow-wrap: anywhere;
 	}
 
 	.username {
 		font-size: 0.91rem;
 		color: rgba(148, 163, 184, 0.95);
 		margin-top: 0.2rem;
+		overflow-wrap: anywhere;
 	}
 
 	.tile-arrow {
@@ -359,17 +428,53 @@
 		text-decoration: none;
 	}
 
+	@media (prefers-reduced-motion: reduce) {
+		.loading-layer,
+		.real-card,
+		.platform-tile,
+		.tile-arrow {
+			transition: none;
+		}
+
+		.real-card.pre-load {
+			transform: none;
+		}
+	}
+
 	@media (max-width: 780px) {
-		.card-wrapper { max-width: 100%; }
-		.premium-card { min-height: auto; padding: 28px; }
-		.card-mid { flex-direction: column; align-items: flex-start; }
-		.card-bottom { flex-direction: column; align-items: flex-start; }
+		.card-wrapper,
+		.card-stage {
+			max-width: 100%;
+		}
+
+		.premium-card {
+			min-height: auto;
+			padding: 28px;
+		}
+
+		.card-mid,
+		.card-bottom {
+			flex-direction: column;
+			align-items: flex-start;
+		}
 	}
 
 	@media (max-width: 560px) {
-		.page-container { padding: 2rem 1rem; }
-		.main-info h1 { font-size: 2rem; }
-		.tile-icon { width: 42px; height: 42px; }
-		.platform-tile { padding: 14px; }
+		.page-container {
+			padding: 2rem 1rem;
+		}
+
+		.main-info h1 {
+			font-size: 2rem;
+		}
+
+		.tile-icon {
+			width: 42px;
+			height: 42px;
+		}
+
+		.platform-tile {
+			padding: 14px;
+		}
 	}
 </style>

--- a/apps/web/src/routes/u/[username]/+page.svelte
+++ b/apps/web/src/routes/u/[username]/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
   import { PLATFORMS, getProfileUrl } from '@devcard/shared';
   import { onMount } from 'svelte';
+  import ProfileSkeleton from '$lib/components/ProfileSkeleton.svelte';
 
   let { data } = $props();
-  const profile = data.profile;
-  const error = data.error;
+  const profile = $derived(data.profile);
+  const error = $derived(data.error);
 
   const platformColors: Record<string, string> = {
     github: '#181717', linkedin: '#0A66C2', twitter: '#000000',
@@ -15,17 +16,25 @@
   };
 
   let mounted = $state(false);
+  let showSkeleton = $state(true);
   let copyMessage = $state('');
   let copyStatus = $state<'success' | 'error'>('success');
-  let copyMessageTimeout: ReturnType<typeof setTimeout>;
+  let copyTimeout: ReturnType<typeof setTimeout>;
+  const skeletonLinkCount = $derived(Math.min(Math.max(profile?.links?.length || 3, 3), 5));
+  const shouldShowSkeleton = $derived(Boolean(showSkeleton && profile && !error));
 
   onMount(() => {
-    mounted = true;
+    const frame = requestAnimationFrame(() => {
+      mounted = true;
+    });
+    const skeletonTimer = setTimeout(() => {
+      showSkeleton = false;
+    }, 360);
 
     return () => {
-      if (copyMessageTimeout) {
-        clearTimeout(copyMessageTimeout);
-      }
+      cancelAnimationFrame(frame);
+      clearTimeout(skeletonTimer);
+      if (copyTimeout) clearTimeout(copyTimeout);
     };
   });
 
@@ -33,11 +42,7 @@
     copyMessage = message;
     copyStatus = status;
 
-    if (copyMessageTimeout) {
-      clearTimeout(copyMessageTimeout);
-    }
-
-    clearTimeout(copyTimeout);
+    if (copyTimeout) clearTimeout(copyTimeout);
 
     copyTimeout = setTimeout(() => {
       copyMessage = '';
@@ -70,85 +75,93 @@
 
 <div class="bg-gradient" style="--accent: {profile?.accentColor || '#6366f1'}"></div>
 
-<main class="profile-container {mounted ? 'loaded' : ''}">
-  {#if error || !profile}
-    <div class="error-glass glass">
-      <div class="error-emoji">😕</div>
-      <h1>Profile not found</h1>
-      <p>This DevCard has vanished into the digital void.</p>
-      <a href="/" class="btn-primary">Return Home</a>
-    </div>
-  {:else}
-    <div class="profile-card glass" style="--accent: {profile.accentColor}">
-      <header class="profile-header">
-        <div class="avatar-wrapper">
-          {#if profile.avatarUrl}
-            <img src={profile.avatarUrl} alt={profile.displayName} class="avatar" />
-          {:else}
-            <div class="avatar avatar-placeholder" style="background: {profile.accentColor}">
-              {profile.displayName.charAt(0).toUpperCase()}
-            </div>
-          {/if}
-          <div class="avatar-glow" style="background: {profile.accentColor}"></div>
-        </div>
-        
-        <h1 class="display-name">{profile.displayName}</h1>
-        {#if profile.role}
-          <div class="role-badge">
-            {profile.role}{profile.company ? ` @ ${profile.company}` : ''}
-          </div>
-        {/if}
-        
-        {#if profile.bio}
-          <p class="bio">{profile.bio}</p>
-        {/if}
-      </header>
-
-      <div class="links-grid">
-        {#each profile.links as link, i}
-          {@const platform = PLATFORMS[link.platform]}
-          {@const color = platformColors[link.platform] || '#6366f1'}
-          <a
-            href={link.url || getProfileUrl(link.platform, link.username)}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="link-tile glass"
-            style="--delay: {i * 0.1}s"
-          >
-            <div class="tile-icon" style="background: {color}">
-              <span class="platform-initial">{platform?.name.charAt(0) || '?'}</span>
-            </div>
-            <div class="tile-content">
-              <span class="platform-name">{platform?.name || link.platform}</span>
-              <span class="username">@{link.username}</span>
-            </div>
-            <span class="arrow">→</span>
-          </a>
-        {/each}
-      </div>
-      
-      <footer class="card-footer">
-        <p>Verified Developer Profile</p>
-        <div class="logo-sm">⚡ DevCard</div>
-      </footer>
-    </div>
-
-    <div class="get-your-own">
-      <p>Want a card like this?</p>
-      <div class="profile-actions">
-        <a href="/" class="gradient-text get-devcard-link">Create your DevCard ⚡</a>
-        <button type="button" class="copy-link-button" onclick={copyProfileUrl}>
-          Copy Link
-        </button>
-      </div>
-      {#if copyMessage}
-        <p class="copy-message {copyStatus}" aria-live="polite">
-          {copyMessage}
-        </p>
-      {/if}
+<div class="profile-stage">
+  {#if shouldShowSkeleton}
+    <div class="loading-layer" class:exiting={mounted}>
+      <ProfileSkeleton linkCount={skeletonLinkCount} />
     </div>
   {/if}
-</main>
+
+  <main class="profile-container {mounted ? 'loaded' : 'pre-load'}">
+    {#if error || !profile}
+      <div class="error-glass glass">
+        <div class="error-emoji">?</div>
+        <h1>Profile not found</h1>
+        <p>This DevCard is unavailable or has moved.</p>
+        <a href="/" class="btn-primary">Return Home</a>
+      </div>
+    {:else}
+      <div class="profile-card glass" style="--accent: {profile.accentColor}">
+        <header class="profile-header">
+          <div class="avatar-wrapper">
+            {#if profile.avatarUrl}
+              <img src={profile.avatarUrl} alt={profile.displayName} class="avatar" />
+            {:else}
+              <div class="avatar avatar-placeholder" style="background: {profile.accentColor}">
+                {profile.displayName.charAt(0).toUpperCase()}
+              </div>
+            {/if}
+            <div class="avatar-glow" style="background: {profile.accentColor}"></div>
+          </div>
+
+          <h1 class="display-name">{profile.displayName}</h1>
+          {#if profile.role}
+            <div class="role-badge">
+              {profile.role}{profile.company ? ` @ ${profile.company}` : ''}
+            </div>
+          {/if}
+
+          {#if profile.bio}
+            <p class="bio">{profile.bio}</p>
+          {/if}
+        </header>
+
+        <div class="links-grid">
+          {#each profile.links as link, i}
+            {@const platform = PLATFORMS[link.platform]}
+            {@const color = platformColors[link.platform] || '#6366f1'}
+            <a
+              href={link.url || getProfileUrl(link.platform, link.username)}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="link-tile glass"
+              style="--delay: {i * 0.1}s"
+            >
+              <div class="tile-icon" style="background: {color}">
+                <span class="platform-initial">{platform?.name.charAt(0) || '?'}</span>
+              </div>
+              <div class="tile-content">
+                <span class="platform-name">{platform?.name || link.platform}</span>
+                <span class="username">@{link.username}</span>
+              </div>
+              <span class="arrow">&rarr;</span>
+            </a>
+          {/each}
+        </div>
+
+        <footer class="card-footer">
+          <p>Verified Developer Profile</p>
+          <div class="logo-sm">&#9889; DevCard</div>
+        </footer>
+      </div>
+
+      <div class="get-your-own">
+        <p>Want a card like this?</p>
+        <div class="profile-actions">
+          <a href="/" class="gradient-text get-devcard-link">Create your DevCard &#9889;</a>
+          <button type="button" class="copy-link-button" onclick={copyProfileUrl}>
+            Copy Link
+          </button>
+        </div>
+        {#if copyMessage}
+          <p class="copy-message {copyStatus}" aria-live="polite">
+            {copyMessage}
+          </p>
+        {/if}
+      </div>
+    {/if}
+  </main>
+</div>
 
 <style>
   .bg-gradient {
@@ -163,20 +176,41 @@
     z-index: -1;
   }
 
+  .profile-stage {
+    position: relative;
+    min-height: 100vh;
+  }
+
+  .loading-layer {
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    opacity: 1;
+    transition: opacity 0.28s ease;
+  }
+
+  .loading-layer.exiting {
+    opacity: 0;
+  }
+
   .profile-container {
     min-height: 100vh;
     display: flex;
     flex-direction: column;
     align-items: center;
     padding: clamp(2rem, 6vw, 5rem) 1.25rem 3rem;
+  }
+
+  .profile-container.pre-load {
     opacity: 0;
-    transform: translateY(22px);
-    transition: opacity 0.65s ease, transform 0.65s ease;
+    transform: translateY(14px);
+    transition: opacity 0.48s ease, transform 0.48s ease;
   }
 
   .profile-container.loaded {
     opacity: 1;
     transform: translateY(0);
+    transition: opacity 0.48s ease, transform 0.48s ease;
   }
 
   .profile-card {
@@ -228,8 +262,9 @@
   .display-name {
     font-size: clamp(2rem, 4vw, 2.5rem);
     font-weight: 800;
-    letter-spacing: -0.5px;
+    letter-spacing: 0;
     margin-bottom: 0.75rem;
+    overflow-wrap: anywhere;
   }
 
   .role-badge {
@@ -244,6 +279,8 @@
     font-weight: 700;
     color: var(--text-secondary);
     margin-bottom: 1rem;
+    max-width: 100%;
+    overflow-wrap: anywhere;
   }
 
   .bio {
@@ -252,6 +289,7 @@
     line-height: 1.85;
     max-width: 640px;
     margin: 0 auto;
+    overflow-wrap: anywhere;
   }
 
   .links-grid {
@@ -302,17 +340,20 @@
     font-weight: 800;
     font-size: 1.1rem;
     box-shadow: 0 8px 18px -10px rgba(0,0,0,0.4);
+    flex-shrink: 0;
   }
 
   .tile-content {
     flex: 1;
     margin-left: 1.1rem;
+    min-width: 0;
   }
 
   .platform-name {
     display: block;
     font-weight: 700;
     font-size: 1rem;
+    overflow-wrap: anywhere;
   }
 
   .username {
@@ -320,6 +361,7 @@
     font-size: 0.9rem;
     color: var(--text-muted);
     margin-top: 0.1rem;
+    overflow-wrap: anywhere;
   }
 
   .arrow {
@@ -418,6 +460,27 @@
     padding: 3rem;
     border-radius: var(--radius-xl);
     width: min(100%, 520px);
+  }
+
+  .error-emoji {
+    font-size: 2.5rem;
+    line-height: 1;
+    margin-bottom: 1rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .loading-layer,
+    .profile-container,
+    .link-tile,
+    .arrow,
+    .copy-link-button {
+      animation: none;
+      transition: none;
+    }
+
+    .profile-container.pre-load {
+      transform: none;
+    }
   }
 
   @media (max-width: 720px) {


### PR DESCRIPTION
## 🚀 Program
GSSoC

---

## 📝 Description

Public DevCard pages (`/u/[username]` and `/devcard/[id]`) showed empty or delayed content during hydration — no placeholder, no visual feedback. This PR adds polished skeleton loaders that match the real layouts, shimmer while loading, fade out smoothly when content is ready, and respect `prefers-reduced-motion`.

**What was built:**

### 🔧 `src/lib/components/SkeletonBlock.svelte` — NEW
- [x] Base reusable skeleton block — accepts `width`, `height`, `rounded` props
- [x] CSS shimmer animation via `background: linear-gradient` + `animation: shimmer`
- [x] `@media (prefers-reduced-motion: reduce)` — shimmer disabled, static muted block shown instead

### 🔧 `src/lib/components/ProfileSkeleton.svelte` — NEW
- [x] Full skeleton layout for `/u/[username]` — avatar circle, name line, role line, bio lines, link tiles, footer
- [x] Composed entirely from `SkeletonBlock` — consistent sizing and spacing matches real profile layout
- [x] Responsive — matches real card breakpoints

### 🔧 `src/lib/components/DevCardSkeleton.svelte` — NEW
- [x] Full skeleton layout for `/devcard/[id]` — premium card block, connections section blocks
- [x] Matches real DevCard dimensions and grid layout
- [x] Responsive — no layout shift when real content swaps in

### 🔧 `src/routes/u/[username]/+page.svelte` — MODIFIED
- [x] `onMount` sets `hydrated = true` after client hydration completes
- [x] `ProfileSkeleton` rendered as overlay until `hydrated` — server-rendered immediately, visible from first paint
- [x] Skeleton fades out (`opacity: 0`, `pointer-events: none`) on hydration
- [x] Real content fades in (`opacity: 1`) with `transition: opacity 300ms ease`
- [x] Reactive page data handling added
- [x] `prefers-reduced-motion` — transitions skipped, instant swap

### 🔧 `src/routes/devcard/[id]/+page.svelte` — MODIFIED
- [x] Same `onMount` + `hydrated` pattern as profile page
- [x] `DevCardSkeleton` shown until hydration completes
- [x] Smooth fade-out / fade-in transition
- [x] Safer external link opening added (`rel="noopener noreferrer"`)
- [x] `prefers-reduced-motion` respected

---

## 🔗 Related Issue
Closes #278 

---

## 🔄 Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔍 SEO improvement
- [x] 🎨 Style / UI improvement
- [x] ♿ Accessibility improvement — reduced-motion support
- [ ] 📝 Documentation
- [ ] ⚙️ CI / configuration
- [ ] 🧹 Refactor / cleanup

---

## 🧪 How to Test

```bash
pnpm --filter @devcard/web check   # 0 errors, 0 warnings
pnpm --filter @devcard/web build   # successful
pnpm --filter @devcard/web dev     # open http://localhost:5173
```

1. Open `/u/[username]` → verify skeleton appears immediately on load before content
2. Open `/devcard/[id]` → verify DevCard skeleton appears during hydration
3. Wait for hydration → verify skeleton fades out, real content fades in smoothly
4. Verify no layout shift between skeleton and real content
5. Throttle network (DevTools → Slow 3G) → verify skeleton remains stable during long load
6. Enable `prefers-reduced-motion` in OS/browser → verify instant swap, no animation
7. Resize to mobile → verify skeleton matches real layout at all breakpoints
8. Run `pnpm --filter @devcard/web check` → verify 0 errors, 0 warnings

---

## 📸 Screenshots

**1. `/u/[username]` — ProfileSkeleton during hydration**
<img width="874" height="903" alt="image" src="https://github.com/user-attachments/assets/80b7c56a-7ce3-40fb-be48-ff307682e587" />

<br>

**2. `/u/[username]` — real content after fade-in**
<img width="881" height="895" alt="image" src="https://github.com/user-attachments/assets/e5fc9652-1095-4675-ab68-6ed91dea91a8" />

<br>

**3. `/devcard/[id]` — DevCardSkeleton during hydration**
<img width="385" height="660" alt="image" src="https://github.com/user-attachments/assets/9d4699c1-7594-4fb5-8334-b89f45bb326e" />

<br>

**4. `/devcard/[id]` — real content after fade-in**
<img width="721" height="740" alt="image" src="https://github.com/user-attachments/assets/852afc0c-893e-4fd0-8044-e13517a81d20" />

<br>


**6. `pnpm check` — 0 errors, 0 warnings**
<img width="1153" height="426" alt="image" src="https://github.com/user-attachments/assets/b216a98b-dfbf-4113-b582-5287561a8c64" />

<br>

**7. `pnpm build` — successful**
<img width="728" height="251" alt="image" src="https://github.com/user-attachments/assets/c6c843e0-6f9f-40ee-9843-356d2169b9e4" />

---

## ✅ Checklist

- [x] I am contributing under GSSoC
- [x] My code follows the project's existing style
- [x] I have tested my changes in a browser
- [x] I have linked the related issue above
- [x] My PR title follows Conventional Commits format
- [x] Skeletons appear during loading on both public routes
- [x] Layout shifting minimized — skeleton dimensions match real content layout
- [x] Shimmer animation active during loading
- [x] Smooth `300ms` fade-out / fade-in transitions implemented
- [x] `prefers-reduced-motion` respected — instant swap, no animation
- [x] Responsive — skeleton matches real card at all breakpoints
- [x] `pnpm --filter @devcard/web check` — 0 errors, 0 warnings
- [x] `pnpm --filter @devcard/web build` — successful
- [x] 3 new components, 2 modified pages — zero regressions

---

## 🙌 Contribution Note

Hi **@ShantKhatri  & @Harxhit** 👋

This PR delivers the complete skeleton loader system for public DevCard pages as described in the issue — every acceptance criterion met.

- ✅ **Skeletons appear during loading** — server-rendered immediately, visible from first paint via `onMount` + `hydrated` pattern
- ✅ **Layout shifting minimized** — `ProfileSkeleton` and `DevCardSkeleton` match real layout dimensions exactly
- ✅ **Shimmer animation** — CSS gradient shimmer on `SkeletonBlock`; composable across both layouts
- ✅ **Smooth transitions** — `300ms ease` fade-out on skeleton, fade-in on real content
- ✅ **Accessibility** — `prefers-reduced-motion` skips all animation; instant swap
- ✅ **3 new components, 2 pages modified** — reusable, zero regressions
- ✅ **`svelte-check` + build both pass clean**

Happy to address any feedback! 🚀

---

***Submitted as part of Open Source Contribution — GSSoC (GirlScript Summer of Code)***