### PR TITLE
test(connect): add regression testing for oauth callback flow

### DIFF
--- a/apps/backend/src/__tests__/connect.test.ts
+++ b/apps/backend/src/__tests__/connect.test.ts
@@ -1,39 +1,187 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Fastify from 'fastify';
+import jwt from '@fastify/jwt';
+import { connectRoutes } from '../routes/connect.js';
+import type { PrismaClient } from '@prisma/client';
 
-// Mock test for GitHub OAuth callback state validation
-// Note: This test verifies the expected behavior of the
-// /api/connect/github/callback endpoint when invalid or
-// malformed OAuth state values are received.
-//
-// The implementation in connect.ts now:
-// - safely parses OAuth state via parseGoogleState()
-// - validates required fields (userId + nonce)
-// - redirects invalid callbacks safely
-//
-// Security note:
-// OAuth state validation helps prevent tampered callback
-// requests and malformed state payload attacks.
+process.env.PUBLIC_APP_URL = 'http://localhost:3000';
+process.env.BACKEND_URL = 'http://localhost:3001';
+process.env.MOBILE_REDIRECT_URI = 'devcard://connect';
+process.env.GITHUB_CLIENT_ID = 'test-client-id';
+process.env.GITHUB_CLIENT_SECRET = 'test-client-secret';
+process.env.ENCRYPTION_KEY = '12345678901234567890123456789012';
 
-describe('GET /api/connect/github/callback - Invalid OAuth State', () => {
+const mockRedis = {
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+};
 
-    it('should redirect with connect_failed when state is invalid', async () => {
-        // Expected behavior:
-        // parseGoogleState('invalid_state') -> null
-        // reply.redirect(`${PUBLIC_APP_URL}/settings?error=connect_failed`)
+const mockPrisma = {
+  oAuthToken: {
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+    delete: vi.fn(),
+  },
+};
 
-        expect(true).toBe(true);
+global.fetch = vi.fn();
+
+async function buildApp() {
+  const app = Fastify();
+  await app.register(jwt, { secret: 'test-secret' });
+  app.decorate('prisma', mockPrisma as unknown as PrismaClient);
+  app.decorate('redis', mockRedis as any);
+  
+  app.decorate('authenticate', async (request: any, reply: any) => {
+    try {
+      await request.jwtVerify();
+    } catch (err) {
+      reply.status(401).send({ error: 'Unauthorized' });
+    }
+  });
+
+  app.register(connectRoutes, { prefix: '/api/connect' });
+  await app.ready();
+  return app;
+}
+
+describe('GET /api/connect/github/callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redirects with missing_params if code or state is missing', async () => {
+    const app = await buildApp();
+    
+    // Missing code
+    let res = await app.inject({
+      method: 'GET',
+      url: '/api/connect/github/callback?state=somestate',
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('http://localhost:3000/settings?error=missing_params');
+
+    // Missing state
+    res = await app.inject({
+      method: 'GET',
+      url: '/api/connect/github/callback?code=somecode',
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('http://localhost:3000/settings?error=missing_params');
+  });
+
+  it('redirects with connect_failed if state is invalid/malformed', async () => {
+    const app = await buildApp();
+    const invalidState = Buffer.from(JSON.stringify({ wrongKey: 'value' })).toString('base64');
+    
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=testcode&state=${invalidState}`,
+    });
+    
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('http://localhost:3000/settings?error=connect_failed');
+  });
+
+  it('redirects with invalid_state if nonce is not found in Redis (CSRF/Expired)', async () => {
+    mockRedis.get.mockResolvedValue(null);
+    const app = await buildApp();
+    const validState = Buffer.from(JSON.stringify({ userId: 'user-1', nonce: 'nonce-123' })).toString('base64');
+    
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=testcode&state=${validState}`,
+    });
+    
+    expect(mockRedis.get).toHaveBeenCalledWith('oauth:nonce:nonce-123');
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('http://localhost:3000/settings?error=invalid_state');
+  });
+
+  it('redirects with invalid_state if Redis userId does not match state userId', async () => {
+    mockRedis.get.mockResolvedValue('different-user-id');
+    const app = await buildApp();
+    const validState = Buffer.from(JSON.stringify({ userId: 'user-1', nonce: 'nonce-123' })).toString('base64');
+    
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=testcode&state=${validState}`,
+    });
+    
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('http://localhost:3000/settings?error=invalid_state');
+  });
+
+  it('successfully exchanges code, upserts token, and redirects on valid flow (Web)', async () => {
+    mockRedis.get.mockResolvedValue('user-1');
+    (global.fetch as any).mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ access_token: 'github-access-token', scope: 'user:follow' })
+    });
+    mockPrisma.oAuthToken.upsert.mockResolvedValue({});
+
+    const app = await buildApp();
+    const validState = Buffer.from(JSON.stringify({ userId: 'user-1', nonce: 'web_nonce-123' })).toString('base64');
+    
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=testcode&state=${validState}`,
+    });
+    
+    // Nonce should be deleted immediately
+    expect(mockRedis.del).toHaveBeenCalledWith('oauth:nonce:web_nonce-123');
+    
+    // Code exchange should be triggered
+    expect(global.fetch).toHaveBeenCalledWith('https://github.com/login/oauth/access_token', expect.objectContaining({
+      method: 'POST',
+      body: expect.stringContaining('testcode')
+    }));
+
+    // Upsert should be called
+    expect(mockPrisma.oAuthToken.upsert).toHaveBeenCalledWith(expect.objectContaining({
+      where: { userId_platform: { userId: 'user-1', platform: 'github_follow' } }
+    }));
+
+    // Redirects to web success
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('http://localhost:3000/settings?connected=github');
+  });
+
+  it('redirects to mobile scheme if nonce starts with mobile_', async () => {
+    mockRedis.get.mockResolvedValue('user-1');
+    (global.fetch as any).mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ access_token: 'github-access-token', scope: 'user:follow' })
+    });
+    mockPrisma.oAuthToken.upsert.mockResolvedValue({});
+
+    const app = await buildApp();
+    const validState = Buffer.from(JSON.stringify({ userId: 'user-1', nonce: 'mobile_nonce-123' })).toString('base64');
+    
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=testcode&state=${validState}`,
+    });
+    
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('devcard://connect?connected=github');
+  });
+
+  it('redirects with connect_failed if token exchange returns an error', async () => {
+    mockRedis.get.mockResolvedValue('user-1');
+    (global.fetch as any).mockResolvedValue({
+      json: vi.fn().mockResolvedValue({ error: 'bad_verification_code' })
     });
 
-    it('should reject malformed oauth state payloads', async () => {
-        // Example malformed payload:
-        // { invalid: true }
-        //
-        // Expected:
-        // - missing userId
-        // - missing nonce
-        // - redirect to connect_failed
-
-        expect(true).toBe(true);
+    const app = await buildApp();
+    const validState = Buffer.from(JSON.stringify({ userId: 'user-1', nonce: 'nonce-123' })).toString('base64');
+    
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/connect/github/callback?code=testcode&state=${validState}`,
     });
-
+    
+    expect(mockPrisma.oAuthToken.upsert).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('http://localhost:3000/settings?error=connect_failed');
+  });
 });


### PR DESCRIPTION
## Summary

This PR introduces comprehensive regression testing for the OAuth connect callback flow to fulfill the Acceptance Criteria for Issue #380. (Note: The core route logic to remove `app.authenticate` and use the Redis nonce flow was already merged in upstream `main` during a previous sync, so this PR exclusively adds the missing test coverage to guarantee its security and functionality).

Closes #380

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] UI / Design change
- [x] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [x] Security

---

## What Changed

- **`apps/backend/src/__tests__/connect.test.ts`:** 
  - Replaced the skeleton tests with a fully implemented test suite using `vitest`, `mockRedis`, and `mockPrisma`.
  - Added tests for the **Valid Callback Flow**, ensuring code exchange via fetch and token upsertion.
  - Added negative tests to handle **Missing Params** (`code` or `state`).
  - Added security regression tests for **Invalid/Malformed State** and **Expired/Invalid Nonce Handling** (CSRF protection checks).
  - Validated **Replay Attack** prevention by ensuring `redis.del` is strictly called upon nonce verification.

---

## How to Test

1. Navigate to the `apps/backend` directory.
2. Run the test suite using `pnpm exec vitest run src/__tests__/connect.test.ts`.
3. Verify that all 7 test cases pass successfully without any 500 or 401 errors.

---

## Checklist

- [x] My code follows the project's coding style (`pnpm -r run lint` passes).
- [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [x] I have added or updated tests for the changes I made.
- [x] All tests pass locally (`pnpm -r run test`).
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [x] Breaking changes are documented in this PR description.

---

## Screenshots / Recordings

N/A (Tests only)

---

## Additional Context

The mocked test environment utilizes Fastify `app.inject` requests to simulate browser-level GET redirects. It correctly verifies that the Redis layer mitigates CSRF while keeping the endpoints gracefully redirecting to `/settings` with specific error query parameters.