### PR TITLE
fix(analytics): uniqueViewers now uses COUNT(DISTINCT viewer_id) instead of inflated groupBy

### DIFF
--- a/apps/backend/src/routes/analytics.ts
+++ b/apps/backend/src/routes/analytics.ts
@@ -69,13 +69,14 @@ export async function analyticsRoutes(
       // Count unique viewers
       // In raw SQL this is `SELECT COUNT(DISTINCT viewer_id) FROM card_views WHERE owner_id = ?`
       // Prisma group-by as workaround:
-      const uniqueViewersQuery =
-        await app.prisma.cardView.groupBy({
-          by: ['viewerId', 'viewerIp'],
-          where: { ownerId: userId },
-        });
+      const uniqueViewersQuery = await app.prisma.$queryRaw<[{ count: bigint }]>`
+        SELECT COUNT(DISTINCT viewer_id) AS count
+        FROM card_views
+        WHERE owner_id = ${userId}
+        AND viewer_id IS NOT NULL
+      `;
 
-      const uniqueViewers = uniqueViewersQuery.length;
+      const uniqueViewers = Number(uniqueViewersQuery[0]?.count ?? 0);
 
       return {
         totalViews,


### PR DESCRIPTION
## Summary

Fixes #436

The `uniqueViewers` field in `GET /api/analytics/overview` was computed using `groupBy(['viewerId', 'viewerIp'])`, which groups on a composite key. A single authenticated viewer visiting from two different IPs produced two group rows and was counted as two unique viewers. Anonymous visitors (viewerId = null) with different IPs each added separate rows, causing severe overcounting on public profiles.

## Changes

- Replace the `cardView.groupBy` workaround with a `$queryRaw` executing `COUNT(DISTINCT viewer_id)` — the correct SQL the code comment itself described but did not implement
- Anonymous views (`viewer_id IS NULL`) are explicitly excluded from the distinct count; they represent unidentifiable sessions and cannot be meaningfully deduplicated
- `BigInt` returned by `$queryRaw` is cast to `Number` before returning

## Testing

- Seed one authenticated viewer with 5 views across 3 distinct IPs → `uniqueViewers` must equal 1
- Seed 3 anonymous views from 3 distinct IPs → must not inflate the count
- Seed 3 distinct authenticated viewers → `uniqueViewers` must equal 3
- Verified existing analytics tests pass with updated assertions

## Notes

If tracking anonymous unique visitors becomes a requirement in future, a separate `uniqueAnonymousVisitors` field using `COUNT(DISTINCT viewer_ip)` can be added with explicit documentation of its limitations.