### PR TITLE
fix: improve feature card readability and contrast (#319)

### DIFF
--- a/apps/web/src/pages/LandingPage.css
+++ b/apps/web/src/pages/LandingPage.css
@@ -73,36 +73,35 @@
   gap: 1.75rem;
   padding: 4rem 0 5rem;
 }
-
 .feature-card {
+  position: relative;
+  overflow: hidden;
   padding: 2.4rem;
   min-height: 140px;
   border-radius: var(--radius-xl);
   box-shadow: var(--shadow-lg);
   background: var(--bg-card);
   border: 1px solid var(--border);
-  transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+  transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease, background 0.35s ease;
 }
 
 .feature-card:hover {
-  transform: translateY(-8px);
-  border-color: rgba(99, 102, 241, 0.4);
-  box-shadow: 0 26px 50px -18px rgba(0, 0, 0, 0.35);
+  transform: translateY(-6px);
+  border-color: rgba(99, 102, 241, 0.55);
+  box-shadow: 0 26px 50px -18px rgba(99, 102, 241, 0.3);
 }
 
-.feature-icon {
-  font-size: 2.3rem;
-  margin-bottom: 1.4rem;
-}
+
 
 .feature-card h3 {
   font-size: 1.4rem;
   margin-bottom: 0.9rem;
+  color: var(--text-primary);
 }
-
 .feature-card p {
+  font-size: 0.97rem;
   color: var(--text-secondary);
-  line-height: 1.7;
+  line-height: 1.75;
 }
 
 .footer {
@@ -146,4 +145,95 @@
   .bg-glow {
     opacity: 0.6;
   }
+}
+
+
+.dark .feature-card h3 {
+  color: #f1f5f9;
+}
+
+.dark .feature-card p {
+  color: #cbd5e1;
+}
+
+
+:root:not(.dark) .feature-card h3 {
+  color: #0f172a;
+}
+
+:root:not(.dark) .feature-card p {
+  color: #475569;
+}
+
+:root:not(.dark) .feature-card {
+  box-shadow: 0 4px 24px rgba(99, 102, 241, 0.10), 
+              0 1.5px 6px rgba(0,0,0,0.07);
+  border-color: rgba(99, 102, 241, 0.18);
+}
+
+:root:not(.dark) .feature-card:hover {
+  box-shadow: 0 8px 32px rgba(99, 102, 241, 0.18),
+              0 2px 8px rgba(0,0,0,0.08);
+  border-color: rgba(99, 102, 241, 0.45);
+}
+
+
+.dark .feature-card {
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.35);
+}
+
+.feature-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, #6366f1, #a855f7, #6366f1);
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.feature-card:hover::before {
+  opacity: 1;
+}
+
+
+.feature-icon {
+  font-size: 2rem;
+  margin-bottom: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: rgba(99, 102, 241, 0.12);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+
+.dark .feature-icon {
+  background: rgba(99, 102, 241, 0.15);
+  border-color: rgba(99, 102, 241, 0.25);
+}
+
+
+:root:not(.dark) .feature-icon {
+  background: rgba(99, 102, 241, 0.08);
+  border-color: rgba(99, 102, 241, 0.15);
+}
+
+
+.dark .feature-card:hover {
+  background: rgba(99, 102, 241, 0.06);
+  box-shadow: 0 0 0 1px rgba(99, 102, 241, 0.2),
+              0 26px 50px -18px rgba(99, 102, 241, 0.35);
+}
+
+:root:not(.dark) .feature-card:hover {
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 8px 32px rgba(99, 102, 241, 0.18),
+              0 0 0 1px rgba(99, 102, 241, 0.15);
 }


### PR DESCRIPTION
## Summary
Improves the readability and accessibility of feature cards on the landing page.
Fixes low text contrast, missing base styles, and light/dark theme inconsistencies
in the new React architecture.
Closes #319

---
## Type of Change
- [x] Bug fix
- [x] UI / Design change

---
## What Changed
- Added `position: relative` and `overflow: hidden` to `.feature-card` base styles
- Added explicit `color: var(--text-primary)` on `.feature-card h3` for reliable heading contrast
- Added `.feature-card p` with `font-size: 0.97rem` and `line-height: 1.75` for better readability
- Dark mode WCAG AAA contrast — headings `#f1f5f9`, body text `#cbd5e1`
- Light mode explicit colors — headings `#0f172a`, body text `#475569`
- Enhanced card border visibility in both themes
- Improved `box-shadow` depth for card separation from background
- Added gradient top accent border on hover via `::before` pseudo-element
- Premium icon wrapper with indigo background and border
- Added `background 0.35s ease` for smooth theme switching transition

---
## How to Test
1. Run `cd apps/web && pnpm dev` and open `http://localhost:5173`
2. Scroll to feature cards — verify text is clearly readable in dark mode
3. Click theme toggle — verify cards display correctly in light mode
4. Hover over cards — verify smooth lift + indigo border glow animation

---
## Checklist
- [x] My code follows the project's coding style (`pnpm -r run lint` passes).
- [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [ ] I have added or updated tests for the changes I made.
- [x] All tests pass locally (`pnpm -r run test`).
- [x] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description.

---
## Screenshots / Recordings
<img width="800" height="454" alt="react" src="https://github.com/user-attachments/assets/85bece16-cf0d-4191-a7da-7084b547a9e9" />


---
## Additional Context
This is a re-implementation of PR #405 which was closed because the project
migrated from SvelteKit to React. All contrast ratios now meet WCAG AA/AAA
standards in both light and dark themes.