### PR TITLE
fix(auth): persist provider connection state for Google OAuth

### DIFF
--- a/apps/backend/src/__tests__/auth.test.ts
+++ b/apps/backend/src/__tests__/auth.test.ts
@@ -43,7 +43,7 @@ describe('GET /auth/google/callback', () => {
     process.env.GOOGLE_CLIENT_ID = 'test-google-id';
     process.env.GOOGLE_CLIENT_SECRET = 'test-google-secret';
     process.env.ENCRYPTION_KEY = '12345678901234567890123456789012';
-    
+
     global.fetch = vi.fn();
   });
 
@@ -103,12 +103,14 @@ describe('GET /auth/google/callback', () => {
         }),
       })
     );
+
+    await app.close();
   });
 
   it('allows authentication to succeed even if token persistence fails', async () => {
     const mockUser = { id: 'user-123', username: 'testuser' };
     mockPrisma.user.upsert.mockResolvedValue(mockUser);
-    
+
     // Simulate upsert failure
     mockPrisma.oAuthToken.upsert.mockRejectedValue(new Error('DB Error'));
 
@@ -127,7 +129,7 @@ describe('GET /auth/google/callback', () => {
       });
 
     const app = await buildApp();
-    
+
     // Spy on app.log.error to ensure it gets logged
     const logSpy = vi.spyOn(app.log, 'error');
 
@@ -142,11 +144,13 @@ describe('GET /auth/google/callback', () => {
     // Should still succeed and redirect to dashboard
     expect(res.statusCode).toBe(302);
     expect(res.headers.location).toBe('http://localhost:3000/dashboard');
-    
+
     // Verify the error was logged
     expect(logSpy).toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'user-123' }),
       'Failed to persist Google OAuth token — authentication proceeds'
     );
+
+    await app.close();
   });
 });

--- a/apps/backend/src/__tests__/auth.test.ts
+++ b/apps/backend/src/__tests__/auth.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Fastify from 'fastify';
+import jwt from '@fastify/jwt';
+import cookie from '@fastify/cookie';
+import { authRoutes } from '../routes/auth.js';
+import type { PrismaClient } from '@prisma/client';
+
+process.env.NODE_ENV = 'test';
+process.env.PUBLIC_APP_URL = 'http://localhost:3000';
+process.env.BACKEND_URL = 'http://localhost:3001';
+process.env.MOBILE_REDIRECT_URI = 'devcard://auth';
+process.env.GOOGLE_CLIENT_ID = 'test-google-id';
+process.env.GOOGLE_CLIENT_SECRET = 'test-google-secret';
+process.env.ENCRYPTION_KEY = '12345678901234567890123456789012';
+
+const mockPrisma = {
+  user: {
+    upsert: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  oAuthToken: {
+    upsert: vi.fn(),
+  },
+};
+
+global.fetch = vi.fn();
+
+async function buildApp() {
+  const app = Fastify();
+  await app.register(jwt, { secret: 'test-secret' });
+  await app.register(cookie);
+  app.decorate('prisma', mockPrisma as unknown as PrismaClient);
+
+  app.register(authRoutes, { prefix: '/auth' });
+  await app.ready();
+  return app;
+}
+
+describe('GET /auth/google/callback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persists Google OAuthToken upon successful login', async () => {
+    const mockUser = { id: 'user-123', username: 'testuser' };
+    mockPrisma.user.upsert.mockResolvedValue(mockUser);
+    mockPrisma.oAuthToken.upsert.mockResolvedValue({});
+
+    (global.fetch as any)
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({
+          access_token: 'fake-google-token',
+          scope: 'openid email profile',
+        }),
+      }) // tokenRes
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({
+          id: 'google-id-123',
+          email: 'test@gmail.com',
+          name: 'Test User',
+          picture: 'https://avatar.com/test',
+        }),
+      }); // userRes
+
+    const app = await buildApp();
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/auth/google/callback?code=fake-code&state=fake-state',
+      cookies: {
+        oauth_state: 'fake-state',
+      },
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('http://localhost:3000/dashboard');
+
+    // Verify user upsert
+    expect(mockPrisma.user.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { provider_providerId: { provider: 'google', providerId: 'google-id-123' } },
+      })
+    );
+
+    // Verify oAuthToken upsert
+    expect(mockPrisma.oAuthToken.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId_platform: { userId: 'user-123', platform: 'google' } },
+        create: expect.objectContaining({
+          platform: 'google',
+          scopes: 'openid email profile',
+        }),
+      })
+    );
+  });
+});

--- a/apps/backend/src/__tests__/auth.test.ts
+++ b/apps/backend/src/__tests__/auth.test.ts
@@ -1,17 +1,11 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import Fastify from 'fastify';
-import jwt from '@fastify/jwt';
 import cookie from '@fastify/cookie';
-import { authRoutes } from '../routes/auth.js';
-import type { PrismaClient } from '@prisma/client';
+import jwt from '@fastify/jwt';
+import Fastify from 'fastify';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-process.env.NODE_ENV = 'test';
-process.env.PUBLIC_APP_URL = 'http://localhost:3000';
-process.env.BACKEND_URL = 'http://localhost:3001';
-process.env.MOBILE_REDIRECT_URI = 'devcard://auth';
-process.env.GOOGLE_CLIENT_ID = 'test-google-id';
-process.env.GOOGLE_CLIENT_SECRET = 'test-google-secret';
-process.env.ENCRYPTION_KEY = '12345678901234567890123456789012';
+import { authRoutes } from '../routes/auth.js';
+
+import type { PrismaClient } from '@prisma/client';
 
 const mockPrisma = {
   user: {
@@ -23,7 +17,8 @@ const mockPrisma = {
   },
 };
 
-global.fetch = vi.fn();
+const originalEnv = process.env;
+const originalFetch = global.fetch;
 
 async function buildApp() {
   const app = Fastify();
@@ -39,6 +34,21 @@ async function buildApp() {
 describe('GET /auth/google/callback', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.NODE_ENV = 'test';
+    process.env.PUBLIC_APP_URL = 'http://localhost:3000';
+    process.env.BACKEND_URL = 'http://localhost:3001';
+    process.env.MOBILE_REDIRECT_URI = 'devcard://auth';
+    process.env.GOOGLE_CLIENT_ID = 'test-google-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-google-secret';
+    process.env.ENCRYPTION_KEY = '12345678901234567890123456789012';
+    
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
   });
 
   it('persists Google OAuthToken upon successful login', async () => {
@@ -91,6 +101,51 @@ describe('GET /auth/google/callback', () => {
           scopes: 'openid email profile',
         }),
       })
+    );
+  });
+
+  it('allows authentication to succeed even if token persistence fails', async () => {
+    const mockUser = { id: 'user-123', username: 'testuser' };
+    mockPrisma.user.upsert.mockResolvedValue(mockUser);
+    
+    // Simulate upsert failure
+    mockPrisma.oAuthToken.upsert.mockRejectedValue(new Error('DB Error'));
+
+    (global.fetch as any)
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({
+          access_token: 'fake-google-token',
+        }),
+      })
+      .mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({
+          id: 'google-id-123',
+          email: 'test@gmail.com',
+          name: 'Test User',
+        }),
+      });
+
+    const app = await buildApp();
+    
+    // Spy on app.log.error to ensure it gets logged
+    const logSpy = vi.spyOn(app.log, 'error');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/auth/google/callback?code=fake-code&state=fake-state',
+      cookies: {
+        oauth_state: 'fake-state',
+      },
+    });
+
+    // Should still succeed and redirect to dashboard
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('http://localhost:3000/dashboard');
+    
+    // Verify the error was logged
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-123' }),
+      'Failed to persist Google OAuth token — authentication proceeds'
     );
   });
 });

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -235,10 +235,11 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
       try {
         const encryptedToken = encrypt(tokenData.access_token);
         const scopes = tokenData.scope || 'openid email profile';
+        const platform = 'google' as const;
         await app.prisma.oAuthToken.upsert({
-          where: { userId_platform: { userId: user.id, platform: 'google' } },
+          where: { userId_platform: { userId: user.id, platform } },
           update: { accessToken: encryptedToken, scopes },
-          create: { userId: user.id, platform: 'google', accessToken: encryptedToken, scopes },
+          create: { userId: user.id, platform, accessToken: encryptedToken, scopes },
         });
       } catch (err) {
         app.log.error({ err, userId: user.id }, 'Failed to persist Google OAuth token — authentication proceeds');

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,6 +1,7 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { encrypt } from '../utils/encryption.js';
 import { buildOAuthState, getMobileRedirectUri } from '../services/authService.js';
+import { encrypt } from '../utils/encryption.js';
+
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 
 const GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
 const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
@@ -232,10 +233,11 @@ export async function authRoutes(app: FastifyInstance) {
 
       try {
         const encryptedToken = encrypt(tokenData.access_token);
+        const scopes = tokenData.scope || 'openid email profile';
         await app.prisma.oAuthToken.upsert({
           where: { userId_platform: { userId: user.id, platform: 'google' } },
-          update: { accessToken: encryptedToken, scopes: tokenData.scope || 'openid email profile' },
-          create: { userId: user.id, platform: 'google', accessToken: encryptedToken, scopes: tokenData.scope || 'openid email profile' },
+          update: { accessToken: encryptedToken, scopes },
+          create: { userId: user.id, platform: 'google', accessToken: encryptedToken, scopes },
         });
       } catch (err) {
         app.log.error({ err, userId: user.id }, 'Failed to persist Google OAuth token — authentication proceeds');
@@ -268,7 +270,7 @@ export async function authRoutes(app: FastifyInstance) {
       const server = request.server as any;
       if (typeof server?.authenticate === 'function') { await server.authenticate(request, reply); return }
       if (typeof (app as any).authenticate === 'function') { await (app as any).authenticate(request, reply); return }
-      try { await request.jwtVerify() } catch (e) { reply.status(401).send({ error: 'Unauthorized' }) }
+      try { await request.jwtVerify() } catch (_e) { reply.status(401).send({ error: 'Unauthorized' }) }
     }] }, async (request: FastifyRequest, reply: FastifyReply) => {
     const userId = (request.user as any).id;
     const user = await app.prisma.user.findUnique({

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -230,6 +230,17 @@ export async function authRoutes(app: FastifyInstance) {
         },
       });
 
+      try {
+        const encryptedToken = encrypt(tokenData.access_token);
+        await app.prisma.oAuthToken.upsert({
+          where: { userId_platform: { userId: user.id, platform: 'google' } },
+          update: { accessToken: encryptedToken, scopes: tokenData.scope || 'openid email profile' },
+          create: { userId: user.id, platform: 'google', accessToken: encryptedToken, scopes: tokenData.scope || 'openid email profile' },
+        });
+      } catch (err) {
+        app.log.error({ err, userId: user.id }, 'Failed to persist Google OAuth token — authentication proceeds');
+      }
+
       const token = app.jwt.sign({ id: user.id, username: user.username }, { expiresIn: '30d' });
 
       if (request.query.state?.startsWith('mobile_')) {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the Google OAuth login flow authenticated the user but failed to persist the provider connection metadata (`oAuthToken`). By ensuring that Google's access token is explicitly upserted into the `oAuthToken` table upon successful login, downstream integrations that rely on provider connection states can now consistently identify Google-linked accounts, matching the behavior of the GitHub login flow.

Closes #493

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] UI / Design change
- [x] Tests only (includes new regression tests)
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- **`apps/backend/src/routes/auth.ts`**: 
  - Inserted an `app.prisma.oAuthToken.upsert` block inside the `GET /google/callback` handler immediately after the user is created/updated.
  - Used `encrypt(tokenData.access_token)` to securely persist the token.
  - Hardcoded the `google` platform name and extracted the exact scopes (defaulting to `openid email profile`) so that the integration state matches what downstream integrations expect.
- **`apps/backend/src/__tests__/auth.test.ts`**:
  - Added a new regression test suite leveraging `app.inject` and a mocked global `fetch` to simulate the Google authentication token/user endpoints.
  - Verified that `prisma.oAuthToken.upsert` successfully triggers with the right payload, preventing any future regressions on this flow.

---

## How to Test

1. Navigate to the backend folder (`cd apps/backend`).
2. Run the specific auth tests: `pnpm exec vitest run src/__tests__/auth.test.ts`.
3. Verify that the new tests successfully pass, confirming that the token is correctly upserted into the database mock.
4. **Manual Validation (Optional):** Start the server, login via Google OAuth, and check the database (or via the `/auth/me` endpoint) to ensure your Google `oAuthToken` is correctly linked to your user account.

---

## Checklist

- [x] My code follows the project's coding style (`pnpm -r run lint` passes).
- [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [x] I have added or updated tests for the changes I made.
- [x] All tests pass locally (`pnpm -r run test`). *(Note: The newly added auth tests pass perfectly. Any pre-existing failures in other modules like `team.test.ts` are from recent upstream refactoring)*
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [x] Breaking changes are documented in this PR description.

---

## Screenshots / Recordings

N/A (Backend logic only)

---

## Additional Context

This ensures parity across all authentication providers, avoiding unpredictable behaviour where some providers silently left users without linked connection entries.