### PR TITLE
fix(workflow): use pull_request_target for PR triage

### DIFF
--- a/.github/workflows/triagePr.yml
+++ b/.github/workflows/triagePr.yml
@@ -1,7 +1,7 @@
 name: Pull request triage
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:


### PR DESCRIPTION
## Summary

Switches the pull request triage workflow from `pull_request` to `pull_request_target` to ensure the workflow has the required permissions to apply labels and post comments on pull requests.

During testing, workflow logs showed that the `GITHUB_TOKEN` was being granted read-only permissions, causing label and comment operations to fail with `403 Resource not accessible by integration`. Using `pull_request_target` resolves this by running the workflow with the permissions of the target repository.

---

## What Changed

* Updated the PR triage workflow trigger from `pull_request` to `pull_request_target`.
* Fixed permission issues preventing automatic labeling and reviewer notification.
* Verified the workflow can access the required write permissions for PR triage actions.

---


