### PR TITLE
fix: correct repository URL in LandingPage

### DIFF
--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -45,7 +45,7 @@ export default function LandingPage() {
               Get Started Free
             </Link>
             <a
-              href="https://github.com/ShantKhatri/DevCard"
+              href="https://github.com/Dev-Card/DevCard"
               target="_blank"
               rel="noopener noreferrer"
               className="btn-secondary"
@@ -70,7 +70,7 @@ export default function LandingPage() {
           <p>
             Built with ❤️ by the{' '}
             <a
-              href="https://github.com/ShantKhatri/DevCard"
+              href="https://github.com/Dev-Card/DevCard"
               target="_blank"
               rel="noopener noreferrer"
               className="gradient-text"


### PR DESCRIPTION
## Summary
Fixes incorrect repository URLs in `LandingPage.tsx` that were pointing to `ShantKhatri/DevCard` instead of the correct organization repo `Dev-Card/DevCard`. Both the "Star on GitHub" CTA button and the footer community link are affected.

Closes #503

## Type of Change
- [x] Bug fix

## What Changed
- Updated "Star on GitHub" CTA button href (~line 38) from `ShantKhatri/DevCard` to `Dev-Card/DevCard`
- Updated footer "DevCard" community link href (~line 52) from `ShantKhatri/DevCard` to `Dev-Card/DevCard`

## How to Test
1. Run the app locally and open the landing page
2. Click the "⭐ Star on GitHub" button - should redirect to `https://github.com/Dev-Card/DevCard`
3. Click the "DevCard" link in the footer - should redirect to `https://github.com/Dev-Card/DevCard`


## Checklist
- [x] My code follows the project's coding style (`pnpm -r run lint` passes).
- [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [ ] I have added or updated tests for the changes I made.
- [x] All tests pass locally (`pnpm -r run test`).
- [x] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description.


## Additional Context
No logic changes - purely a hardcoded URL correction. No breaking changes.