### PR TITLE
fix: Added gssoc:approved label for opening new prs

### DIFF
--- a/.github/scripts/triagePr.js
+++ b/.github/scripts/triagePr.js
@@ -10,7 +10,7 @@ module.exports = async ({github, context}) => {
     const mobileFiles = []; 
     const devopsFiles = []; 
 
-    const labels = []; 
+    const labels = ['gssoc:approved']; 
     let primaryArea = null;
     let reviewer = null; 
 


### PR DESCRIPTION
## Summary

Automatically applies the gssoc:approved label to newly triaged issues. This removes the need for maintainers to manually add the label during issue triage, ensuring consistent labeling while reducing repetitive moderation work.