### PR TITLE
refactor(auth): type jwt user payload and drop any casts (#541)

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -7,7 +7,7 @@ import helmet from '@fastify/helmet';
 import jwt from '@fastify/jwt';
 import multipart from '@fastify/multipart';
 import rateLimit from '@fastify/rate-limit';
-import Fastify, {type FastifyInstance} from 'fastify';
+import Fastify, {type FastifyInstance, type FastifyReply, type FastifyRequest} from 'fastify';
 
 import { prismaPlugin } from './plugins/prisma.js';
 import { redisPlugin } from './plugins/redis.js';
@@ -23,6 +23,8 @@ import { publicRoutes } from './routes/public.js';
 import { teamRoutes } from './routes/team.js';
 import { extractRawJwt, blocklistKey } from './utils/jwt.js';
 import { validateEnv } from './utils/validateEnv.js';
+
+import type { AuthenticatedUser } from './types/fastify.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -104,7 +106,7 @@ export async function buildApp():Promise<FastifyInstance> {
   // Checks the Redis blocklist before calling jwtVerify so that a logged-out
   // token is rejected immediately even if it has not yet expired.
   // The blocklist check is skipped when Redis is not registered (test env).
-  app.decorate('authenticate', async function (request: any, reply: any) {
+  app.decorate('authenticate', async function (request: FastifyRequest, reply: FastifyReply) {
     try {
       if (app.hasDecorator('redis')) {
         const raw = extractRawJwt(request);
@@ -122,7 +124,7 @@ export async function buildApp():Promise<FastifyInstance> {
         }
       }
       // Assign verified payload to request.user (upstream addition).
-      const payload = await request.jwtVerify();
+      const payload = await request.jwtVerify<AuthenticatedUser>();
       if (payload) { request.user = payload; }
     } catch (_err) {
       return reply.status(401).send({ error: 'Unauthorized' });

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -676,7 +676,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
             await app.redis.set(blocklistKey(raw), '1', 'EX', ttl);
           } catch (err) {
             // Non-fatal: log and continue. The token will expire on its own.
-            app.log.warn({ err, userId: (request.user as any)?.id }, 'Redis blocklist write failed during logout — token will expire naturally');
+            app.log.warn({ err, userId: request.user?.id }, 'Redis blocklist write failed during logout — token will expire naturally');
           }
         }
       } else {

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -613,7 +613,7 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     preHandler: [app.authenticate],
   }, async (request: FastifyRequest, reply: FastifyReply) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const user = await app.prisma.user.findUnique({
       where: { id: userId },
       select: {

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -1,6 +1,6 @@
 import '@fastify/cookie';
 import '@fastify/jwt';
-import { FastifyRequest } from 'fastify';
+import { FastifyReply, FastifyRequest } from 'fastify';
 
 export interface AuthenticatedUser {
   id: string;
@@ -16,5 +16,9 @@ declare module '@fastify/jwt' {
 declare module 'fastify' {
   interface FastifyRequest {
     cookies: Record<string, string | undefined>;
+  }
+
+  interface FastifyInstance {
+    authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
   }
 }

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -1,5 +1,17 @@
 import '@fastify/cookie';
+import '@fastify/jwt';
 import { FastifyRequest } from 'fastify';
+
+export interface AuthenticatedUser {
+  id: string;
+  username: string;
+}
+
+declare module '@fastify/jwt' {
+  interface FastifyJWT {
+    user: AuthenticatedUser;
+  }
+}
 
 declare module 'fastify' {
   interface FastifyRequest {


### PR DESCRIPTION
## summary

this PR removes the remaining `any` usages in the backend auth module and replaces them with proper fastify types and a dedicated jwt payload interface.
 this closes out the `auth.ts scope of the type-safety umbrella issue, so `request.user` and the `authenticate` decorator are now type-checked instead of being cast away.

Fixes #541



## type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- 9added an `AuthenticatedUser { id, username } ` interface in `apps/backend/src/types/fastify.d.ts` and augmented `@fastify/jwt`'s `FastifyJWT` interface so `request.user` is typed. went through `Fasti `FastifyRequest.user` directly since `@fastify/jwt`already owns that field and doing it the other way would clash

- declared the `authenticate` decorator on `FastifyInstan.authenticate` is no longer untyped
- typed the `authenticate` decorator in `apps/backend/src/app.ts` (`request: any, reply: any` to `FastifyRequest, FastifyReply`) and passed the
user shape through `request.jwtVerify<AuthenticatedUser>(
- dropped the `(request.user as any)` casts in `apps/backend/src/routes/auth.ts` (the `/me` route and the secure logout route).

---

## How to Test

1. `npm run typecheck -w apps/backend` passes with no errors
2. `npm run lint -w apps/backend` stays clean
3. 4, `npx vitest run src/__tests__/logout.test.ts` 

---

## Checklist

- [x] My code follows the project's coding style 
- [x] TypeScript compiles without errors (`npm run typecheck`).
- [ ] I have added or updated tests for the changes I mad
- [x] All tests pass locally 
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [x] Breaking changes are documented in this PR descript

---

## Screenshots / Recordings

n/a, no ui changes.

---

## Additional Context