### PR TITLE
fix: removed lint check for web modules from github checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,8 @@ jobs:
         run: npm --prefix apps/web run build
 
       - name: Fail job if any check failed
-        if: steps.web_build.outcome == 'failure'
+        if: >
+          steps.web_build.outcome == 'failure'
         run: exit 1
 
   mobile-ci:


### PR DESCRIPTION
## Summary

Removed linting checks from web module from github actions

---

## Type of Change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [X] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## Checklist

- [ ] My code follows the project's coding style (`pnpm -r run lint` passes).
- [ ] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [ ] I have added or updated tests for the changes I made.
- [ ] All tests pass locally (`pnpm -r run test`).
- [ ] I have updated documentation where necessary.
- [ ] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description.
