### PR TITLE
refactor(analytics): replace any casts with typed prehandler and prisma where clause (#546)

### DIFF
--- a/apps/backend/src/routes/analytics.ts
+++ b/apps/backend/src/routes/analytics.ts
@@ -12,14 +12,14 @@ export async function analyticsRoutes(
     '/overview',
     {
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      preHandler: [async (request, reply) => { const server = request.server as any; if (typeof server?.authenticate === 'function') { await server.authenticate(request, reply); return } if (typeof (app as any).authenticate === 'function') { await (app as any).authenticate(request, reply); return } try { await request.jwtVerify() } catch (e) { reply.status(401).send({ error: 'Unauthorized' }) } }],
+      preHandler: [app.authenticate],
     },
     async (
       request: FastifyRequest,
       _reply: FastifyReply
     ) => {
-      const userId = (request.user as any).id;
-      const username = (request.user as any).username;  
+      const userId = request.user.id;
+      const username = request.user.username;
 
       const today = new Date();
       today.setHours(0, 0, 0, 0);
@@ -98,7 +98,7 @@ export async function analyticsRoutes(
     '/views',
     {
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      preHandler: [async (request, reply) => { const server = request.server as any; if (typeof server?.authenticate === 'function') { await server.authenticate(request, reply); return } if (typeof (app as any).authenticate === 'function') { await (app as any).authenticate(request, reply); return } try { await request.jwtVerify() } catch (e) { reply.status(401).send({ error: 'Unauthorized' }) } }],
+      preHandler: [app.authenticate],
     },
     async (
       request: FastifyRequest<{
@@ -109,7 +109,7 @@ export async function analyticsRoutes(
       }>,
       _reply: FastifyReply
     ) => {
-      const userId = (request.user as any).id;
+      const userId = request.user.id;
       const page = parseInt(request.query.page || '1', 10);
       const limit = 20;
       const skip = (page - 1) * limit;

--- a/apps/backend/src/routes/analytics.ts
+++ b/apps/backend/src/routes/analytics.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client';
 import type {
   FastifyInstance,
   FastifyRequest,
@@ -114,7 +115,7 @@ export async function analyticsRoutes(
       const limit = 20;
       const skip = (page - 1) * limit;
 
-      const whereClause: any = { ownerId: userId };
+      const whereClause: Prisma.CardViewWhereInput = { ownerId: userId };
 
       if (request.query.cardId) {
         whereClause.cardId = request.query.cardId;

--- a/apps/backend/src/types/fastify.d.ts
+++ b/apps/backend/src/types/fastify.d.ts
@@ -1,8 +1,25 @@
 import '@fastify/cookie';
-import { FastifyRequest } from 'fastify';
+import '@fastify/jwt';
+import { FastifyRequest, FastifyReply } from 'fastify';
 
 declare module 'fastify' {
+  interface FastifyInstance {
+    authenticate: (
+      request: FastifyRequest,
+      reply: FastifyReply
+    ) => Promise<void>;
+  }
+
   interface FastifyRequest {
     cookies: Record<string, string | undefined>;
+  }
+}
+
+declare module '@fastify/jwt' {
+  interface FastifyJWT {
+    user: {
+      id: string;
+      username: string;
+    };
   }
 }


### PR DESCRIPTION
## Summary

the pr removes the remaining `any` usages in the analytics routes and replaces the hand-rolled inline auth preHandler with the shared `app.authenticate` decorator, so `request.user` and the prisma where clause are properly typed instead of cast to `any`. this is the analytics.ts slice of the type-safety umbrella.

Fixes #546

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- replaced the inline preHandler in both analytics routes (which cast `request.server as any` and `(app as any).authenticate` and fell back to a manual `jwtVerify`) with `preHandler: [app.authenticate]`, the same decorator the rest of the backend uses.
- dropped the `(request.user as any).id` / `.username` casts in `apps/backend/src/routes/analytics.ts` and used `request.user.id` / `request.user.username` directly.
- typed the views query filter as `Prisma.CardViewWhereInput` instead of `const whereClause: any`, with `import type { Prisma } from '@prisma/client'`.
- in `apps/backend/src/types/fastify.d.ts`, declared the `authenticate` decorator on `FastifyInstance` and augmented `@fastify/jwt`'s `FastifyJWT` so `request.user` carries `{ id, username }`. went through `FastifyJWT` rather than augmenting `FastifyRequest.user` directly because `@fastify/jwt` already owns that field.

---

## How to Test

1. `npm run typecheck -w apps/backend` passes with no errors.
2. the changed files lint clean (`npx eslint src/routes/analytics.ts` is clean). 
3. hit `GET /api/analytics/overview` and `GET /api/analytics/views` with a valid token and confirm they still return the same data, and that an unauthenticated request still gets a 401. behaviour is unchanged, this is types and a swap to the shared auth decorator.

---

## Checklist

- [x] My code follows the project's coding style (changed files lint clean; pre-existing repo lint errors are out of scope).
- [x] TypeScript compiles without errors (`npm run typecheck`).
- [ ] I have added or updated tests for the changes I made.
- [x] All tests pass locally (no new failures vs main).
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [x] Breaking changes are documented in this PR description.

---

## Screenshots / Recordings

n/a, no ui changes.

---

## Additional Context

scope here is just analytics.ts plus the shared fastify type file, matching #546. the other files in the umbrella (cards, connect, event, etc) have their own sub-issues so they're out of scope. note the template's checklist commands say `pnpm` but the repo moved to npm workspaces, so i ran the npm equivalents