### PR TITLE
refactor(ci): remove web lint check and clean up workflow

### DIFF
--- a/.github/scripts/commentResults.js
+++ b/.github/scripts/commentResults.js
@@ -9,7 +9,6 @@ module.exports = async ({
   backendTypecheck,
   mobileLint,
   mobileTest,
-  webCheck,
   webBuild,
   backendLintOutput,
   mobileLintOutput,
@@ -57,7 +56,6 @@ ${mobileLint === 'failure' ? lintDetails(mobileLintOutput) : ''}
 
 | Check | Result |
 |---|---|
-| Check | ${status(webCheck)} |
 | Build | ${status(webBuild)} |
 
 ---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      check_result: ${{ steps.web_check.outcome }}
       build_result: ${{ steps.web_build.outcome }}
 
     steps:
@@ -108,20 +107,13 @@ jobs:
       - name: Install web dependencies
         run: npm --prefix apps/web install
 
-      - name: Web check
-        id: web_check
-        continue-on-error: true
-        run: npm --prefix apps/web run lint
-
       - name: Web build
         id: web_build
         continue-on-error: true
         run: npm --prefix apps/web run build
 
       - name: Fail job if any check failed
-        if: >
-          steps.web_check.outcome == 'failure' ||
-          steps.web_build.outcome == 'failure'
+        if: steps.web_build.outcome == 'failure'
         run: exit 1
 
   mobile-ci:
@@ -191,7 +183,6 @@ jobs:
               backendLint:      '${{ needs.backend-ci.outputs.lint_result }}',      
               backendTest:      '${{ needs.backend-ci.outputs.test_result }}',
               backendTypecheck: '${{ needs.backend-ci.outputs.typecheck_result }}',
-              webCheck:         '${{ needs.web-ci.outputs.check_result }}',
               webBuild:         '${{ needs.web-ci.outputs.build_result }}',
               mobileLint:       '${{ needs.mobile-ci.outputs.lint_result }}',
               mobileTest:       '${{ needs.mobile-ci.outputs.test_result }}',


### PR DESCRIPTION
## Summary

Closes: #533

* Remove web lint check references from the CI workflow
* Clean up unused web check outputs and reporting
* Keep web validation focused on build checks only
