### PR TITLE
fix: improve type safety in follow.ts by removing `any` usages (#550)

### DIFF
--- a/apps/backend/src/routes/follow.ts
+++ b/apps/backend/src/routes/follow.ts
@@ -1,16 +1,18 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import { getPlatform, getProfileUrl, getWebViewUrl } from '@devcard/shared';
+
 import { decrypt } from '../utils/encryption.js';
 import { getErrorMessage } from '../utils/error.util.js';
-import { getPlatform, getProfileUrl, getWebViewUrl } from '@devcard/shared';
 import { followLogSchema } from '../validations/follow.validation.js';
-import type { AuthenticatedUser } from '../types/fastify.js';
 
-export async function followRoutes(app: FastifyInstance) {
+import type { AuthenticatedUser } from '../types/fastify.js';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
+export async function followRoutes(app: FastifyInstance): Promise<void> {
     app.addHook('preHandler', async (request, reply) => {
     const server = request.server;
     if (typeof server?.authenticate === 'function') { await server.authenticate(request, reply); return }
     if (typeof app.authenticate === 'function') { await app.authenticate(request, reply); return }
-    try { const payload = await request.jwtVerify<AuthenticatedUser>(); if (payload) request.user = payload; } catch (e) { reply.status(401).send({ error: 'Unauthorized' }) }
+    try { const payload = await request.jwtVerify<AuthenticatedUser>(); if (payload) {request.user = payload;} } catch (_e) { reply.status(401).send({ error: 'Unauthorized' }) }
   });
 
   // ─── Follow via API (Layer 1) ───

--- a/apps/backend/src/routes/follow.ts
+++ b/apps/backend/src/routes/follow.ts
@@ -6,11 +6,11 @@ import { followLogSchema } from '../validations/follow.validation.js';
 
 export async function followRoutes(app: FastifyInstance) {
     app.addHook('preHandler', async (request, reply) => {
-      const server = request.server as any;
-      if (typeof server?.authenticate === 'function') { await server.authenticate(request, reply); return }
-      if (typeof (app as any).authenticate === 'function') { await (app as any).authenticate(request, reply); return }
-      try { const payload = await request.jwtVerify(); if (payload) (request as any).user = payload; } catch (e) { reply.status(401).send({ error: 'Unauthorized' }) }
-    });
+    const server = request.server;
+    if (typeof server?.authenticate === 'function') { await server.authenticate(request, reply); return }
+    if (typeof app.authenticate === 'function') { await app.authenticate(request, reply); return }
+    try { const payload = await request.jwtVerify(); if (payload) request.user = payload; } catch (e) { reply.status(401).send({ error: 'Unauthorized' }) }
+  });
 
   // ─── Follow via API (Layer 1) ───
   // Currently supports: GitHub
@@ -19,7 +19,7 @@ export async function followRoutes(app: FastifyInstance) {
     request: FastifyRequest<{ Params: { platform: string; targetUsername: string } }>,
     reply: FastifyReply
   ) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const { platform, targetUsername } = request.params;
 
     // GitHub follow tokens are stored under 'github_follow' to prevent the
@@ -116,7 +116,7 @@ export async function followRoutes(app: FastifyInstance) {
     }>,
     reply: FastifyReply
   ) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const { platform, targetUsername } = request.params;
 
     const parsed = followLogSchema.safeParse(request.body);
@@ -137,8 +137,8 @@ export async function followRoutes(app: FastifyInstance) {
         },
       });
       return reply.send({ status: 'success', logId: log.id });
-    } catch (error: any) {
-      app.log.error('Failed to log follow:', error);
+    } catch (error) {
+      app.log.error(`Failed to log follow: ${getErrorMessage(error)}`);
       return reply.status(500).send({ error: 'Failed to log follow event' });
     }
   });
@@ -148,7 +148,7 @@ export async function followRoutes(app: FastifyInstance) {
     request: FastifyRequest<{ Params: { platform: string; targetUsername: string } }>,
     reply: FastifyReply
   ) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const { platform, targetUsername } = request.params;
 
     await app.prisma.followLog.deleteMany({

--- a/apps/backend/src/routes/follow.ts
+++ b/apps/backend/src/routes/follow.ts
@@ -3,13 +3,14 @@ import { decrypt } from '../utils/encryption.js';
 import { getErrorMessage } from '../utils/error.util.js';
 import { getPlatform, getProfileUrl, getWebViewUrl } from '@devcard/shared';
 import { followLogSchema } from '../validations/follow.validation.js';
+import type { AuthenticatedUser } from '../types/fastify.js';
 
 export async function followRoutes(app: FastifyInstance) {
     app.addHook('preHandler', async (request, reply) => {
     const server = request.server;
     if (typeof server?.authenticate === 'function') { await server.authenticate(request, reply); return }
     if (typeof app.authenticate === 'function') { await app.authenticate(request, reply); return }
-    try { const payload = await request.jwtVerify(); if (payload) request.user = payload; } catch (e) { reply.status(401).send({ error: 'Unauthorized' }) }
+    try { const payload = await request.jwtVerify<AuthenticatedUser>(); if (payload) request.user = payload; } catch (e) { reply.status(401).send({ error: 'Unauthorized' }) }
   });
 
   // ─── Follow via API (Layer 1) ───


### PR DESCRIPTION
## Summary
Removes all remaining `any` usages from `follow.ts` and replaces them with proper Fastify and JWT types, reusing the existing type definitions in `src/types/fastify.d.ts`.

## Changes
- Removed `request.server as any` and `(app as any).authenticate` casts — `FastifyInstance.authenticate` and `request.server` are already properly typed via the existing `fastify.d.ts` augmentation, so no casts are needed.
- Replaced `(request as any).user = payload` with `request.user = payload`, typing the JWT payload using `request.jwtVerify<AuthenticatedUser>()` (imported from `../types/fastify.js`) so it matches the `AuthenticatedUser` type already declared for `request.user`.
- Replaced all three `(request.user as any).id` usages with `request.user.id`.
- Replaced `catch (error: any)` with `catch (error)` and used the existing `getErrorMessage` utility, matching the error-handling pattern already used elsewhere in this file.

## Testing
- `npx tsc --noEmit` passes with no errors.
- Follow route tests: 16/16 passing.

Closes #550