### PR TITLE
feat(auth): add Zod validation for authentication utility endpoints

### DIFF
--- a/apps/backend/src/__tests__/auth.validation.test.ts
+++ b/apps/backend/src/__tests__/auth.validation.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { mobileExchangeSchema, refreshTokenSchema } from '../validations/auth.validation.js';
+
+describe('auth.validation', () => {
+  describe('mobileExchangeSchema', () => {
+    it('accepts a valid UUID code', () => {
+      const result = mobileExchangeSchema.safeParse({
+        code: '550e8400-e29b-41d4-a716-446655440000',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.code).toBe('550e8400-e29b-41d4-a716-446655440000');
+      }
+    });
+
+    it('rejects a non-UUID string', () => {
+      const result = mobileExchangeSchema.safeParse({
+        code: 'not-a-uuid',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.flatten().fieldErrors.code).toBeDefined();
+      }
+    });
+
+    it('rejects missing code', () => {
+      const result = mobileExchangeSchema.safeParse({});
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('refreshTokenSchema', () => {
+    it('accepts a valid refresh_token string', () => {
+      const result = refreshTokenSchema.safeParse({
+        refresh_token: 'some-refresh-token',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts an empty body (refresh_token is optional)', () => {
+      const result = refreshTokenSchema.safeParse({});
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.refresh_token).toBeUndefined();
+      }
+    });
+
+    it('rejects a non-string refresh_token', () => {
+      const result = refreshTokenSchema.safeParse({
+        refresh_token: 123,
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/__tests__/auth.validation.test.ts
+++ b/apps/backend/src/__tests__/auth.validation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { mobileExchangeSchema, refreshTokenSchema } from '../validations/auth.validation.js';
+
+import { mobileExchangeSchema, refreshTokenSchema } from '../validations/auth.validation';
 
 describe('auth.validation', () => {
   describe('mobileExchangeSchema', () => {

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -3,6 +3,7 @@ import { extractRawJwt, blocklistKey, signAccessToken  } from '../utils/jwt.js';
 import { buildOAuthState, getMobileRedirectUri } from '../utils/oauth.js';
 import { generateRefreshToken, hashIp, hashRefreshToken } from '../utils/refreshToken.js';
 
+import { mobileExchangeSchema, refreshTokenSchema } from '../validations/auth.validation.js';
 import type { GitHubTokenErrorResponse, GitHubTokenResponse } from '../utils/error.util.js';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 
@@ -495,7 +496,15 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
   });
 
   app.post('/refresh', async(request: FastifyRequest, reply: FastifyReply) => {
-     const refreshToken = request.cookies.refresh_token ?? (request.body as { refresh_token?: string })?.refresh_token;
+     // Validate request body with Zod
+     const bodyParsed = refreshTokenSchema.safeParse(request.body);
+     if (!bodyParsed.success) {
+       return reply.status(400).send({
+         error: 'Invalid request body',
+         issues: bodyParsed.error.flatten().fieldErrors,
+       });
+     }
+     const refreshToken = request.cookies.refresh_token ?? bodyParsed.data.refresh_token;
 
     if (!refreshToken) {
       return reply.status(401).send({
@@ -599,8 +608,15 @@ export async function authRoutes(app: FastifyInstance): Promise<void> {
 
   })
 
-  app.post('/mobile/exchange', async (request: FastifyRequest<{Body: {code: string}}>, reply: FastifyReply) => {
-    const { code } = request.body;
+  app.post('/mobile/exchange', async (request: FastifyRequest, reply: FastifyReply) => {
+    const parsed = mobileExchangeSchema.safeParse(request.body);
+    if (!parsed.success) {
+      return reply.status(400).send({
+        error: 'Invalid request body',
+        issues: parsed.error.flatten().fieldErrors,
+      });
+    }
+    const { code } = parsed.data;
     const raw = await app.redis.getdel(`mobile_exchange:${code}`);
     if (!raw) {return reply.status(400).send({ error: 'Invalid or expired exchange code' });}
     

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -1,11 +1,12 @@
 import { handleDbError, isGitHubTokenError, isGoogleTokenError } from '../utils/error.util.js';
-import { extractRawJwt, blocklistKey, signAccessToken  } from '../utils/jwt.js';
+import { extractRawJwt, blocklistKey, signAccessToken } from '../utils/jwt.js';
 import { buildOAuthState, getMobileRedirectUri } from '../utils/oauth.js';
 import { generateRefreshToken, hashIp, hashRefreshToken } from '../utils/refreshToken.js';
-
 import { mobileExchangeSchema, refreshTokenSchema } from '../validations/auth.validation';
+
 import type { GitHubTokenErrorResponse, GitHubTokenResponse } from '../utils/error.util.js';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+
 
 interface GitHubEmailResponse {
   email: string;

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -3,7 +3,7 @@ import { extractRawJwt, blocklistKey, signAccessToken  } from '../utils/jwt.js';
 import { buildOAuthState, getMobileRedirectUri } from '../utils/oauth.js';
 import { generateRefreshToken, hashIp, hashRefreshToken } from '../utils/refreshToken.js';
 
-import { mobileExchangeSchema, refreshTokenSchema } from '../validations/auth.validation.js';
+import { mobileExchangeSchema, refreshTokenSchema } from '../validations/auth.validation';
 import type { GitHubTokenErrorResponse, GitHubTokenResponse } from '../utils/error.util.js';
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 

--- a/apps/backend/src/validations/auth.validation.ts
+++ b/apps/backend/src/validations/auth.validation.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const mobileExchangeSchema = z.object({
+  code: z
+    .string({ message: 'Exchange code is required' })
+    .uuid({ message: 'Exchange code must be a valid UUID' }),
+});
+
+export const refreshTokenSchema = z.object({
+  refresh_token: z
+    .string({ message: 'Refresh token must be a string' })
+    .min(1, 'Refresh token cannot be empty')
+    .optional(),
+});


### PR DESCRIPTION
## Summary

Add request validation for  and  using Zod schemas, as described in #540.

## Changes

- **New file** :
  - : validates that  is a valid UUID
  - : validates optional  string in request body

- **Updated** :
  - : validates request body with  before processing
  - : validates request body with 

- **New test file** :
  - Tests for valid/invalid UUID in 
  - Tests for  (string, optional, non-string rejection)

## Acceptance Criteria

- [x]  uses Zod validation
- [x]  uses Zod validation  
- [x] Invalid requests are rejected with validation errors
- [x] Tests added for validation success and failure cases

Part of #540