### PR TITLE
fix(cards): add Serializable isolation + P2034 retry to setDefaultCard

### DIFF
--- a/apps/backend/src/__tests__/cards.test.ts
+++ b/apps/backend/src/__tests__/cards.test.ts
@@ -306,6 +306,117 @@ describe('PUT /api/cards/:id — link ownership validation', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// PUT /api/cards/:id/default — serialization & retry behaviour
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PUT /api/cards/:id/default — serialization isolation & retry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes isolationLevel Serializable to $transaction', async () => {
+    mockPrisma.card.findFirst.mockResolvedValue(mockCard);
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockPrisma) => Promise<unknown>, options?: unknown) => {
+        expect(options).toEqual({ isolationLevel: 'Serializable' });
+        mockPrisma.card.updateMany.mockResolvedValue({ count: 2 });
+        mockPrisma.card.update.mockResolvedValue({ ...mockCard, isDefault: true });
+        return callback(mockPrisma);
+      },
+    );
+
+    const app = await buildApp();
+    const res = await app.inject({ method: 'PUT', url: `/api/cards/${CARD_ID}/default` });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockPrisma.$transaction).toHaveBeenCalledOnce();
+  });
+
+  it('retries on P2034 (serialization conflict) and succeeds on second attempt', async () => {
+    mockPrisma.card.findFirst.mockResolvedValue(mockCard);
+
+    const p2034 = Object.assign(new Error('Serialization failure'), { code: 'P2034' });
+    let callCount = 0;
+
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockPrisma) => Promise<unknown>) => {
+        callCount++;
+        if (callCount === 1) throw p2034;
+        mockPrisma.card.updateMany.mockResolvedValue({ count: 2 });
+        mockPrisma.card.update.mockResolvedValue({ ...mockCard, isDefault: true });
+        return callback(mockPrisma);
+      },
+    );
+
+    const app = await buildApp();
+    const res = await app.inject({ method: 'PUT', url: `/api/cards/${CARD_ID}/default` });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().message).toBe('Default card updated');
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 500 after exhausting all 3 retry attempts on persistent P2034', async () => {
+    mockPrisma.card.findFirst.mockResolvedValue(mockCard);
+
+    const p2034 = Object.assign(new Error('Serialization failure'), { code: 'P2034' });
+    mockPrisma.$transaction.mockRejectedValue(p2034);
+
+    const app = await buildApp();
+    const res = await app.inject({ method: 'PUT', url: `/api/cards/${CARD_ID}/default` });
+
+    expect(res.statusCode).toBe(500);
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry on non-P2034 errors and returns 500 immediately', async () => {
+    mockPrisma.card.findFirst.mockResolvedValue(mockCard);
+
+    const dbError = new Error('Connection lost');
+    mockPrisma.$transaction.mockRejectedValue(dbError);
+
+    const app = await buildApp();
+    const res = await app.inject({ method: 'PUT', url: `/api/cards/${CARD_ID}/default` });
+
+    expect(res.statusCode).toBe(500);
+    // Must not have retried — only one attempt for non-serialization errors
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent calls: the last committed transaction determines the sole default', async () => {
+    mockPrisma.card.findFirst.mockResolvedValue(mockCard);
+
+    let callCount = 0;
+    mockPrisma.$transaction.mockImplementation(
+      async (callback: (tx: typeof mockPrisma) => Promise<unknown>) => {
+        callCount++;
+        // First concurrent attempt fails (simulates DB-level serialization abort)
+        if (callCount === 1) {
+          throw Object.assign(new Error('Serialization failure'), { code: 'P2034' });
+        }
+        mockPrisma.card.updateMany.mockResolvedValue({ count: 2 });
+        mockPrisma.card.update.mockResolvedValue({ ...mockCard, isDefault: true });
+        return callback(mockPrisma);
+      },
+    );
+
+    const app = await buildApp();
+
+    // Fire both requests concurrently
+    const [res1, res2] = await Promise.all([
+      app.inject({ method: 'PUT', url: `/api/cards/${CARD_ID}/default` }),
+      app.inject({ method: 'PUT', url: `/api/cards/${CARD_ID}/default` }),
+    ]);
+
+    // Both callers ultimately succeed (one retried)
+    expect([res1.statusCode, res2.statusCode]).toEqual([200, 200]);
+    // Combined, the transaction was attempted 3 times (1 fail + 1 succeed for
+    // the first caller, 1 succeed for the second — ordering may vary)
+    expect(mockPrisma.$transaction.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // DELETE /api/cards/:id
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/apps/backend/src/__tests__/cards.test.ts
+++ b/apps/backend/src/__tests__/cards.test.ts
@@ -410,9 +410,12 @@ describe('PUT /api/cards/:id/default — serialization isolation & retry', () =>
 
     // Both callers ultimately succeed (one retried)
     expect([res1.statusCode, res2.statusCode]).toEqual([200, 200]);
-    // Combined, the transaction was attempted 3 times (1 fail + 1 succeed for
-    // the first caller, 1 succeed for the second — ordering may vary)
-    expect(mockPrisma.$transaction.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Exactly one global failure point (callCount === 1) is consumed by
+    // whichever request reaches it first; that request retries once and
+    // succeeds, while the other succeeds on its first attempt. Total calls
+    // is therefore deterministic at 3 — which caller hits the retry varies,
+    // the count does not.
+    expect(mockPrisma.$transaction).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/apps/backend/src/__tests__/cards.test.ts
+++ b/apps/backend/src/__tests__/cards.test.ts
@@ -341,7 +341,7 @@ describe('PUT /api/cards/:id/default — serialization isolation & retry', () =>
     mockPrisma.$transaction.mockImplementation(
       async (callback: (tx: typeof mockPrisma) => Promise<unknown>) => {
         callCount++;
-        if (callCount === 1) throw p2034;
+        if (callCount === 1) { throw p2034; }
         mockPrisma.card.updateMany.mockResolvedValue({ count: 2 });
         mockPrisma.card.update.mockResolvedValue({ ...mockCard, isDefault: true });
         return callback(mockPrisma);

--- a/apps/backend/src/services/cardService.ts
+++ b/apps/backend/src/services/cardService.ts
@@ -5,6 +5,15 @@ type CardLinkResponse = { platformLink: unknown };
 type RawCard = { id: string; title: string; isDefault: boolean; cardLinks: CardLinkResponse[] };
 export type CardResponse = { id: string; title: string; isDefault: boolean; links: unknown[] };
 
+function isP2034(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: string }).code === 'P2034'
+  );
+}
+
 function mapCard(card: RawCard): CardResponse {
   return {
     id: card.id,
@@ -178,11 +187,12 @@ export async function setDefaultCard(app: FastifyInstance, userId: string, id: s
 
       return { message: 'Default card updated' };
     } catch (error: unknown) {
-      if (
-        typeof error === 'object' && error !== null && 'code' in error &&
-        (error as { code: string }).code === 'P2034' &&
-        attempt < maxRetries ) {
-        continue;
+      if (isP2034(error)) {
+        if (attempt < maxRetries) {
+          continue;
+        }
+        app.log.error(error);
+        break; // exhausted — fall through to the generic Error below
       }
 
       app.log.error(error);

--- a/apps/backend/src/services/cardService.ts
+++ b/apps/backend/src/services/cardService.ts
@@ -165,10 +165,30 @@ export async function setDefaultCard(app: FastifyInstance, userId: string, id: s
     return null;
   }
 
-  await app.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
-    await tx.card.updateMany({ where: { userId }, data: { isDefault: false } });
-    await tx.card.update({ where: { id }, data: { isDefault: true } });
-  });
+  const maxRetries = 3;
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      await app.prisma.$transaction(
+        async (tx: Prisma.TransactionClient) => {
+          await tx.card.updateMany({ where: { userId }, data: { isDefault: false } });
+          await tx.card.update({ where: { id }, data: { isDefault: true } });
+        },
+        { isolationLevel: 'Serializable' },
+      );
 
-  return { message: 'Default card updated' };
+      return { message: 'Default card updated' };
+    } catch (error: unknown) {
+      if (
+        typeof error === 'object' && error !== null && 'code' in error &&
+        (error as { code: string }).code === 'P2034' &&
+        attempt < maxRetries ) {
+        continue;
+      }
+
+      app.log.error(error);
+      throw error;
+    }
+  }
+
+  throw new Error('Failed to set default card after retrying serialization conflicts');
 }


### PR DESCRIPTION
## Summary

Closes #566.

`setDefaultCard` ran its clear-then-set pair under Postgres's default **Read Committed** isolation. Two concurrent calls for the same user could interleave so that the `updateMany` from Tx2 (clear all defaults) committed *after* Tx1's `update` (set card A as default), wiping the flag without any replacement — leaving the user with **zero** `isDefault: true` cards.

This silently breaks any UI or API logic that assumes exactly one default card exists per user (the invariant that `createCard` and `deleteCard` both uphold carefully).

## Root cause

```ts
// Before — no isolationLevel; runs under Read Committed
await app.prisma.$transaction(async (tx) => {
  await tx.card.updateMany({ where: { userId }, data: { isDefault: false } });
  await tx.card.update({ where: { id }, data: { isDefault: true } });
});
```

Under Read Committed, the two writes are not serialized against concurrent transactions touching the same rows, so lost-update interleavings are possible.

## Fix

Mirror the pattern already used in `createCard`:

1. Pass `{ isolationLevel: 'Serializable' }` to `$transaction` — Postgres will detect write-write conflicts and abort one of the concurrent transactions with `P2034`.
2. Wrap in a retry loop (max 3 attempts), continuing on `P2034` and re-throwing immediately on any other error.

```ts
// After
const maxRetries = 3;
for (let attempt = 1; attempt <= maxRetries; attempt++) {
  try {
    await app.prisma.$transaction(
      async (tx) => {
        await tx.card.updateMany({ where: { userId }, data: { isDefault: false } });
        await tx.card.update({ where: { id }, data: { isDefault: true } });
      },
      { isolationLevel: 'Serializable' },
    );
    return { message: 'Default card updated' };
  } catch (error: unknown) {
    if (isP2034(error) && attempt < maxRetries) continue;
    app.log.error(error);
    throw error;
  }
}
throw new Error('Failed to set default card after retrying serialization conflicts');
```

## Files changed

| File | Change |
|---|---|
| `apps/backend/src/services/cardService.ts` | Add `isolationLevel: 'Serializable'` + P2034 retry loop to `setDefaultCard` |
| `apps/backend/src/__tests__/cards.test.ts` | 5 new tests covering isolation option forwarding, retry on P2034, retry exhaustion, no-retry on non-P2034 errors, concurrent-call race simulation |

## Tests

New test cases in `describe('PUT /api/cards/:id/default — serialization isolation & retry')`:

- ✅ `isolationLevel: 'Serializable'` is passed to `$transaction`
- ✅ Retries on P2034 and succeeds on second attempt
- ✅ Returns 500 after exhausting all 3 attempts on persistent P2034
- ✅ Does not retry non-P2034 errors (single attempt → 500)
- ✅ Concurrent calls: serialization abort → retry → both callers receive 200

## Checklist

- [x] Mirrors the retry pattern already established in `createCard`
- [x] No behaviour change for the happy path
- [x] No new dependencies
- [x] Existing tests still pass