### PR TITLE
fix(backend): remove any usages from public.ts to improve type safety

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -65,29 +65,6 @@
       "resolved": "../../packages/shared",
       "link": true
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1651,6 +1628,7 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -1800,6 +1778,7 @@
       "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.60.1",
@@ -2288,6 +2267,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2496,6 +2476,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3089,6 +3070,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3243,6 +3225,7 @@
       "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@package-json/types": "^0.0.12",
         "@typescript-eslint/types": "^8.56.0",
@@ -4666,6 +4649,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4812,6 +4796,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.3",
         "@prisma/engines": "6.19.3"
@@ -5548,6 +5533,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5672,6 +5658,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/apps/backend/src/routes/public.ts
+++ b/apps/backend/src/routes/public.ts
@@ -90,7 +90,7 @@ export async function publicRoutes(app: FastifyInstance): Promise<void> {
           avatarUrl: card.user.avatarUrl,
           accentColor: card.user.accentColor,
         },
-        links: card.cardLinks.map((cl: any) => ({
+        links: card.cardLinks.map((cl: { platformLink: { id: string; platform: string; username: string; url: string } }) => ({
           id: cl.platformLink.id,
           platform: cl.platformLink.platform,
           username: cl.platformLink.username,
@@ -187,12 +187,12 @@ export async function publicRoutes(app: FastifyInstance): Promise<void> {
     Querystring: { format?: string; size?: string };
   }>, reply: FastifyReply) => {
     const { username } = request.params;
-    const format = (request.query as any).format || 'png';
+    const format = request.query.format || 'png';
 
     // Parse and validate size before touching the DB or allocating any buffers.
     // parseInt safely handles non-numeric strings (returns NaN) and ignores any
     // trailing fractional part, so '400.9' → 400 which is within bounds.
-    const rawSize = (request.query as any).size;
+    const rawSize = request.query.size;
     const size = rawSize !== undefined ? parseInt(rawSize, 10) : 400;
 
     if (!Number.isInteger(size) || size < MIN_QR_SIZE || size > MAX_QR_SIZE) {


### PR DESCRIPTION
## Summary

This PR improves type safety in the public routes by removing the remaining usages of `any` in `apps/backend/src/routes/public.ts`. This ensures strict type-checking on query parameters and mapping functions, making future refactoring safer and more predictable. 

**This issue is solved under GSSoC '26.**

Closes #553 

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- **`apps/backend/src/routes/public.ts`**: Replaced the `(cl: any)` cast in the `getCardById` response mapping with an explicit structural type (`{ platformLink: { id: string; platform: string; username: string; url: string } }`) to maintain strict typing without IDE export errors.
- **`apps/backend/src/routes/public.ts`**: Replaced `(request.query as any).format` and `(request.query as any).size` with properly typed `request.query.format` and `request.query.size`, natively inheriting from the route's `Querystring` schema definition.

---

## How to Test

1. Check out this branch locally: `git checkout fix/public-ts-types`
2. Ensure you have the backend dependencies installed and Prisma generated: `cd apps/backend && npm install`
3. Run the TypeScript compiler to ensure there are no implicit `any` errors: `npm run typecheck`
4. Optionally, start the backend and hit the public card/QR endpoints to verify no functional changes were introduced.

---

## Checklist

- [x] My code follows the project's coding style (`pnpm -r run lint` passes).
- [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [ ] I have added or updated tests for the changes I made. *(N/A - Type updates only)*
- [x] All tests pass locally (`pnpm -r run test`).
- [ ] I have updated documentation where necessary. *(N/A)*
- [x] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description. *(N/A)*

---

## Additional Context

Used structural inline typing for the mapped `platformLink` variable to avoid editor/IDE linting complaints related to cached Prisma generated type exports.
