### PR TITLE
fix(backend): remove any usages from profiles.ts to improve type safety

### DIFF
--- a/apps/backend/src/routes/profiles.ts
+++ b/apps/backend/src/routes/profiles.ts
@@ -1,13 +1,10 @@
-import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { getProfileUrl } from '@devcard/shared';
+import { Prisma } from '@prisma/client';
+
+import * as profileService from '../services/profileService';
 import { updateProfileSchema, createLinkSchema, reorderLinksSchema } from '../utils/validators.js';
-import { getErrorMessage } from '../utils/error.util.js';
-import * as profileService from '../services/profileService'
 
-// ── Response types ────────────────────────────────────────────────────────────
-// Declared explicitly so the API contract is visible without tracing through
-// Prisma's generic return types.  Follows the convention in public.ts.
-
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type ProfileUpdateResponse = {
   id: string;
   email: string;
@@ -21,21 +18,21 @@ type ProfileUpdateResponse = {
   accentColor: string;
 };
 
-export async function profileRoutes(app: FastifyInstance) {
+export async function profileRoutes(app: FastifyInstance): Promise<void> {
   // All profile routes require auth
   app.addHook('preHandler', async (request, reply) => {
-    const server = request.server as any;
+    const server = request.server;
     if (typeof server?.authenticate === 'function') {
       await server.authenticate(request, reply);
       return;
     }
-    if (typeof (app as any).authenticate === 'function') {
-      await (app as any).authenticate(request, reply);
+    if (typeof app.authenticate === 'function') {
+      await app.authenticate(request, reply);
       return;
     }
     try {
       await request.jwtVerify();
-    } catch (e) {
+    } catch (_e) {
       reply.status(401).send({ error: 'Unauthorized' });
     }
   });
@@ -43,16 +40,18 @@ export async function profileRoutes(app: FastifyInstance) {
   // ─── Get Own Profile ───
 
   app.get('/me', async (request: FastifyRequest, reply: FastifyReply) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const user = await profileService.getOwnProfile(app, userId)
-    if (!user) return reply.status(404).send({ error: 'User not found' })
+    if (!user) {
+      return reply.status(404).send({ error: 'User not found' });
+    }
     return user
   });
 
   // ─── Update Profile ───
 
   app.put('/me', async (request: FastifyRequest, reply: FastifyReply) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const parsed = updateProfileSchema.safeParse(request.body);
 
     if (!parsed.success) {
@@ -79,8 +78,10 @@ export async function profileRoutes(app: FastifyInstance) {
     try {
       const response = await profileService.updateProfile(app, userId, parsed.data)
       return response
-    } catch (err: any) {
-      if (err?.code === 'P2002') return reply.status(409).send({ error: 'Username already taken' })
+    } catch (err: unknown) {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === 'P2002') {
+        return reply.status(409).send({ error: 'Username already taken' });
+      }
       app.log.error({ err }, 'DB error in PUT /profiles/me')
       return reply.status(500).send({ error: 'Internal server error' })
     }
@@ -89,7 +90,7 @@ export async function profileRoutes(app: FastifyInstance) {
   // ─── Add Platform Link ───
 
   app.post('/me/links', async (request: FastifyRequest, reply: FastifyReply) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const parsed = createLinkSchema.safeParse(request.body);
 
     if (!parsed.success) {
@@ -99,7 +100,7 @@ export async function profileRoutes(app: FastifyInstance) {
     try {
       const link = await profileService.createPlatformLink(app, userId, parsed.data)
       return reply.status(201).send(link)
-    } catch (err: any) {
+    } catch (err: unknown) {
       app.log.error({ err }, 'Failed to create platform link')
       return reply.status(500).send({ error: 'Internal server error' })
     }
@@ -108,16 +109,20 @@ export async function profileRoutes(app: FastifyInstance) {
   // ─── Update Platform Link ───
 
   app.put('/me/links/:id', async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const { id } = request.params;
 
     const parsedReq = createLinkSchema.safeParse(request.body)
-    if (!parsedReq.success) return reply.status(400).send({ error: 'Validation failed', details: parsedReq.error.flatten() })
+    if (!parsedReq.success) {
+      return reply.status(400).send({ error: 'Validation failed', details: parsedReq.error.flatten() });
+    }
     try {
       const updated = await profileService.updatePlatformLink(app, userId, id, parsedReq.data)
-      if (!updated) return reply.status(404).send({ error: 'Link not found' })
+      if (!updated) {
+        return reply.status(404).send({ error: 'Link not found' });
+      }
       return updated
-    } catch (err: any) {
+    } catch (err: unknown) {
       app.log.error({ err }, 'Failed to update platform link')
       return reply.status(500).send({ error: 'Internal server error' })
     }
@@ -126,14 +131,16 @@ export async function profileRoutes(app: FastifyInstance) {
   // ─── Delete Platform Link ───
 
   app.delete('/me/links/:id', async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const { id } = request.params;
 
     try {
       const deleted = await profileService.deletePlatformLink(app, userId, id)
-      if (!deleted) return reply.status(404).send({ error: 'Link not found' })
+      if (!deleted) {
+        return reply.status(404).send({ error: 'Link not found' });
+      }
       return reply.status(204).send()
-    } catch (err: any) {
+    } catch (err: unknown) {
       app.log.error({ err }, 'Failed to delete platform link')
       return reply.status(500).send({ error: 'Internal server error' })
     }
@@ -142,13 +149,15 @@ export async function profileRoutes(app: FastifyInstance) {
   // ─── Reorder Links ───
 
   app.put('/me/links/reorder', async (request: FastifyRequest, reply: FastifyReply) => {
-    const userId = (request.user as any).id;
+    const userId = request.user.id;
     const parsedReq = reorderLinksSchema.safeParse(request.body)
-    if (!parsedReq.success) return reply.status(400).send({ error: 'Validation failed', details: parsedReq.error.flatten() })
+    if (!parsedReq.success) {
+      return reply.status(400).send({ error: 'Validation failed', details: parsedReq.error.flatten() });
+    }
     try {
       const resp = await profileService.reorderLinks(app, userId, parsedReq.data.links)
       return resp
-    } catch (err: any) {
+    } catch (err: unknown) {
       app.log.error({ err }, 'Failed to reorder links')
       return reply.status(500).send({ error: 'Internal server error' })
     }


### PR DESCRIPTION
## Summary

This PR improves type safety in the profile routes by removing the remaining usages of `any` in `apps/backend/src/routes/profiles.ts`. By leveraging existing Fastify request typings and Prisma error classes, this makes the route handlers and error handling logic safer and more maintainable.

**This issue is solved under GSSoC '26.**

Closes #552 

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- **`apps/backend/src/routes/profiles.ts`**: Replaced `request.server as any` and `(app as any).authenticate` with properly typed Fastify instance property access (`request.server` and `app.authenticate`), leveraging the existing `FastifyInstance` augmentation in `fastify.d.ts`.
- **`apps/backend/src/routes/profiles.ts`**: Replaced all instances of `(request.user as any).id` with `request.user.id`, utilizing the native JWT authentication typings.
- **`apps/backend/src/routes/profiles.ts`**: Replaced unsafe `catch (err: any)` with `catch (err: unknown)` and utilized `Prisma.PrismaClientKnownRequestError` to safely trap `P2002` (unique constraint) errors.

---

## How to Test

1. Check out this branch locally: `git checkout fix/profile-ts-types`
2. Ensure you have the backend dependencies installed and Prisma generated: `cd apps/backend && npm install`
3. Run the TypeScript compiler to ensure there are no implicit `any` errors: `npm run typecheck`
4. Optionally, start the backend and update a profile/link to verify authentication and database calls work exactly as before.

---

## Checklist

- [x] My code follows the project's coding style (`pnpm -r run lint` passes).
- [x] TypeScript compiles without errors (`pnpm -r run typecheck`).
- [ ] I have added or updated tests for the changes I made. *(N/A - Type updates only)*
- [x] All tests pass locally (`pnpm -r run test`).
- [ ] I have updated documentation where necessary. *(N/A)*
- [x] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description. *(N/A)*

---

## Additional Context

No application behavior or logic has been altered. This PR simply removes TS-compiler overrides to improve the codebase quality and safety.
