### PR TITLE
feat(web): add contributor leaderboard page

### DIFF
--- a/.github/scripts/generateLeaderboard.js
+++ b/.github/scripts/generateLeaderboard.js
@@ -1,0 +1,126 @@
+module.exports = async ({ github, context }) => {
+    const owner = context.repo.owner;
+    const repo = context.repo.repo;
+
+    const EXCLUDED = new Set([
+        'shantkhatri',
+        'harxhit',
+        'blankirigaya'
+    ]);
+
+    const contributors = new Map();
+
+    const ensure = (login, avatarUrl, profileUrl) => {
+        if (!contributors.has(login)) {
+            contributors.set(login, {
+                login,
+                avatarUrl,
+                profileUrl,
+                mergedPrs: 0,
+                openPrs: 0,
+                issues: 0
+            });
+        }
+
+        return contributors.get(login);
+    };
+
+    const mergedPrs = await github.paginate(
+        github.rest.pulls.list,
+        {
+            owner,
+            repo,
+            state: 'closed',
+            per_page: 100
+        }
+    );
+
+    for (const pr of mergedPrs) {
+        if (!pr.merged_at) continue;
+        if (!pr.user) continue;
+
+        const login = pr.user.login;
+
+        if (EXCLUDED.has(login.toLowerCase())) continue;
+
+        const user = ensure(
+            login,
+            pr.user.avatar_url,
+            pr.user.html_url
+        );
+
+        user.mergedPrs++;
+    }
+
+    const openPrs = await github.paginate(
+        github.rest.pulls.list,
+        {
+            owner,
+            repo,
+            state: 'open',
+            per_page: 100
+        }
+    );
+
+    for (const pr of openPrs) {
+        if (!pr.user) continue;
+
+        const login = pr.user.login;
+
+        if (EXCLUDED.has(login.toLowerCase())) continue;
+
+        const user = ensure(
+            login,
+            pr.user.avatar_url,
+            pr.user.html_url
+        );
+
+        user.openPrs++;
+    }
+
+    const issues = await github.paginate(
+        github.rest.issues.listForRepo,
+        {
+            owner,
+            repo,
+            state: 'all',
+            per_page: 100
+        }
+    );
+
+    for (const issue of issues) {
+        if (issue.pull_request) continue;
+        if (!issue.user) continue;
+
+        const login = issue.user.login;
+
+        if (EXCLUDED.has(login.toLowerCase())) continue;
+
+        const user = ensure(
+            login,
+            issue.user.avatar_url,
+            issue.user.html_url
+        );
+
+        user.issues++;
+    }
+
+    const leaderboard = [...contributors.values()].sort(
+        (a, b) =>
+            b.mergedPrs - a.mergedPrs ||
+            b.issues - a.issues ||
+            b.openPrs - a.openPrs ||
+            a.login.localeCompare(b.login)
+    );
+
+    const fs = require('fs');
+
+    fs.mkdirSync('public', { recursive: true });
+
+    fs.writeFileSync(
+        'public/leaderboard.json',
+        JSON.stringify(leaderboard, null, 2)
+    );
+
+    console.log(`Generated ${leaderboard.length} contributors`);
+};

--- a/.github/scripts/generateLeaderboard.js
+++ b/.github/scripts/generateLeaderboard.js
@@ -36,8 +36,7 @@ module.exports = async ({ github, context }) => {
     );
 
     for (const pr of mergedPrs) {
-        if (!pr.merged_at) continue;
-        if (!pr.user) continue;
+        if (!pr.merged_at || !pr.user) continue;
 
         const login = pr.user.login;
 
@@ -89,8 +88,7 @@ module.exports = async ({ github, context }) => {
     );
 
     for (const issue of issues) {
-        if (issue.pull_request) continue;
-        if (!issue.user) continue;
+        if (issue.pull_request || !issue.user) continue;
 
         const login = issue.user.login;
 
@@ -114,13 +112,19 @@ module.exports = async ({ github, context }) => {
     );
 
     const fs = require('fs');
+    const path = require('path');
 
-    fs.mkdirSync('public', { recursive: true });
+    const outputDir = path.join('apps', 'web', 'public');
+    const outputFile = path.join(outputDir, 'leaderboard.json');
+
+    fs.mkdirSync(outputDir, { recursive: true });
 
     fs.writeFileSync(
-        'public/leaderboard.json',
-        JSON.stringify(leaderboard, null, 2)
+        outputFile,
+        JSON.stringify(leaderboard, null, 2),
+        'utf8'
     );
 
     console.log(`Generated ${leaderboard.length} contributors`);
+    console.log(`Leaderboard written to ${outputFile}`);
 };

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -1,0 +1,48 @@
+name: Update Leaderboard
+
+on:
+workflow_dispatch:
+schedule:
+- cron: '0 * * * *'
+
+permissions:
+contents: write
+pull-requests: read
+issues: read
+
+jobs:
+leaderboard:
+runs-on: ubuntu-latest
+
+steps:
+  - name: Checkout
+    uses: actions/checkout@v4
+
+  - name: Setup Node
+    uses: actions/setup-node@v4
+    with:
+      node-version: 22
+
+  - name: Generate leaderboard
+    uses: actions/github-script@v7
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      script: |
+        const script = require('./.github/scripts/generateLeaderboard.js');
+        await script({ github, context });
+
+  - name: Commit leaderboard
+    run: |
+      git config user.name "github-actions[bot]"
+      git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      git add public/leaderboard.json
+
+      if git diff --staged --quiet; then
+        echo "No changes to commit"
+        exit 0
+      fi
+
+      git commit -m "chore: update leaderboard"
+      git push
+

--- a/README.md
+++ b/README.md
@@ -307,6 +307,8 @@ Thanks to all the amazing people who contribute to **DevCard** 🚀
   </a>
 </p>
 
+> 🏆 **Contributor Leaderboard** — contributors are also ranked by merged PRs, issues, and open PRs in the web app at the [`/leaderboard`](https://devcard.app/leaderboard) route (`apps/web`).
+
 <br>
 
 ## Project Support

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import LandingPage from './pages/LandingPage';
 import ProfilePage from './pages/ProfilePage';
 import CardPage from './pages/CardPage';
+import LeaderboardPage from './pages/LeaderboardPage';
 import NotFound from './pages/NotFound';
 
 export default function App() {
@@ -10,6 +11,7 @@ export default function App() {
       <Route path="/" element={<LandingPage />} />
       <Route path="/u/:username" element={<ProfilePage />} />
       <Route path="/devcard/:id" element={<CardPage />} />
+      <Route path="/leaderboard" element={<LeaderboardPage />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/apps/web/src/pages/LeaderboardPage.css
+++ b/apps/web/src/pages/LeaderboardPage.css
@@ -1,0 +1,145 @@
+.leaderboard {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 7rem 1.5rem 4rem;
+}
+
+.leaderboard-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.leaderboard-header h1 {
+  font-size: clamp(2.2rem, 5vw, 3.2rem);
+  font-weight: 900;
+  font-family: 'Outfit', sans-serif;
+  margin: 1rem 0 0.75rem;
+}
+
+.leaderboard-subtitle {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  max-width: 520px;
+  margin: 0 auto;
+}
+
+.leaderboard-state {
+  text-align: center;
+  padding: 2.5rem 1.5rem;
+  border-radius: var(--radius-lg);
+  color: var(--text-secondary);
+}
+
+.leaderboard-state.error {
+  color: #ef4444;
+}
+
+.leaderboard-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0;
+}
+
+.leaderboard-row {
+  display: grid;
+  grid-template-columns: 2.5rem 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-lg);
+}
+
+.rank {
+  font-weight: 800;
+  font-size: 1.1rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.rank-1 { color: #f5c518; }
+.rank-2 { color: #c0c5ce; }
+.rank-3 { color: #cd7f32; }
+
+.contributor {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  text-decoration: none;
+  color: var(--text-primary);
+  min-width: 0;
+}
+
+.contributor-avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 2px solid var(--border-glass);
+  flex-shrink: 0;
+}
+
+.contributor-name {
+  font-weight: 600;
+  font-family: 'Outfit', sans-serif;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.contributor:hover .contributor-name {
+  color: var(--primary);
+}
+
+.stats {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 3.5rem;
+}
+
+.stat-value {
+  font-weight: 800;
+  font-size: 1.15rem;
+  color: var(--text-primary);
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.leaderboard-footer {
+  text-align: center;
+  margin-top: 2.5rem;
+}
+
+.leaderboard-footer a {
+  text-decoration: none;
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .leaderboard-row {
+    grid-template-columns: 2rem 1fr;
+    grid-template-areas:
+      'rank contributor'
+      'stats stats';
+    row-gap: 0.85rem;
+  }
+  .rank { grid-area: rank; }
+  .contributor { grid-area: contributor; }
+  .stats {
+    grid-area: stats;
+    justify-content: space-around;
+    width: 100%;
+  }
+}

--- a/apps/web/src/pages/LeaderboardPage.tsx
+++ b/apps/web/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import './LeaderboardPage.css';
+
+const REPO = 'Dev-Card/DevCard';
+const GITHUB_API = 'https://api.github.com';
+
+// Maintainers / accounts excluded from the contributor leaderboard.
+const EXCLUDED = new Set(
+  ['ShantKhatri', 'Harxhit', 'blankirigaya'].map((u) => u.toLowerCase())
+);
+
+type Contributor = {
+  login: string;
+  avatarUrl: string;
+  profileUrl: string;
+  issues: number;
+  mergedPrs: number;
+  openPrs: number;
+};
+
+type GithubContributor = {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  type: string;
+};
+
+type SearchResult = { total_count: number };
+
+async function ghJson<T>(url: string): Promise<T> {
+  const response = await fetch(url, {
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub request failed: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function countSearch(query: string): Promise<number> {
+  const url = `${GITHUB_API}/search/issues?q=${encodeURIComponent(query)}&per_page=1`;
+  const result = await ghJson<SearchResult>(url);
+  return result.total_count;
+}
+
+async function loadContributorStats(login: string): Promise<Pick<Contributor, 'issues' | 'mergedPrs' | 'openPrs'>> {
+  const base = `repo:${REPO} author:${login}`;
+  const [issues, mergedPrs, openPrs] = await Promise.all([
+    countSearch(`${base} type:issue`),
+    countSearch(`${base} type:pr is:merged`),
+    countSearch(`${base} type:pr is:open`),
+  ]);
+  return { issues, mergedPrs, openPrs };
+}
+
+export default function LeaderboardPage() {
+  const [contributors, setContributors] = useState<Contributor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.title = 'Contributor Leaderboard | DevCard';
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const list = await ghJson<GithubContributor[]>(
+          `${GITHUB_API}/repos/${REPO}/contributors?per_page=100`
+        );
+
+        const eligible = list.filter(
+          (c) => c.type === 'User' && !EXCLUDED.has(c.login.toLowerCase())
+        );
+
+        const enriched = await Promise.all(
+          eligible.map(async (c) => {
+            const stats = await loadContributorStats(c.login);
+            return {
+              login: c.login,
+              avatarUrl: c.avatar_url,
+              profileUrl: c.html_url,
+              ...stats,
+            } satisfies Contributor;
+          })
+        );
+
+        enriched.sort(
+          (a, b) =>
+            b.mergedPrs - a.mergedPrs ||
+            b.issues - a.issues ||
+            b.openPrs - a.openPrs ||
+            a.login.localeCompare(b.login)
+        );
+
+        if (!cancelled) setContributors(enriched);
+      } catch {
+        if (!cancelled) setError('Could not load contributors. GitHub may be rate-limiting — try again shortly.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <>
+      <div className="bg-glow" />
+      <Navbar />
+      <main className="leaderboard" id="leaderboard-main">
+        <header className="leaderboard-header">
+          <div className="hero-badge">🏆 Community</div>
+          <h1>
+            <span className="gradient-text">Contributor</span> Leaderboard
+          </h1>
+          <p className="leaderboard-subtitle">
+            The developers building DevCard — ranked by merged pull requests, issues, and open work.
+          </p>
+        </header>
+
+        {loading && (
+          <div className="leaderboard-state glass">Loading contributors…</div>
+        )}
+
+        {error && !loading && (
+          <div className="leaderboard-state glass error">{error}</div>
+        )}
+
+        {!loading && !error && (
+          <ol className="leaderboard-list" id="leaderboard-list">
+            {contributors.map((c, i) => (
+              <li key={c.login} className="leaderboard-row glass">
+                <span className={`rank rank-${i + 1 <= 3 ? i + 1 : 'n'}`}>
+                  {i + 1}
+                </span>
+                <a
+                  href={c.profileUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="contributor"
+                >
+                  <img
+                    src={c.avatarUrl}
+                    alt={c.login}
+                    className="contributor-avatar"
+                    loading="lazy"
+                  />
+                  <span className="contributor-name">@{c.login}</span>
+                </a>
+                <div className="stats">
+                  <span className="stat" title="Merged pull requests">
+                    <span className="stat-value">{c.mergedPrs}</span>
+                    <span className="stat-label">Merged PRs</span>
+                  </span>
+                  <span className="stat" title="Open pull requests">
+                    <span className="stat-value">{c.openPrs}</span>
+                    <span className="stat-label">Open PRs</span>
+                  </span>
+                  <span className="stat" title="Issues created">
+                    <span className="stat-value">{c.issues}</span>
+                    <span className="stat-label">Issues</span>
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+
+        <div className="leaderboard-footer">
+          <Link to="/" className="gradient-text">
+            ← Back to Home
+          </Link>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/apps/web/src/pages/LeaderboardPage.tsx
+++ b/apps/web/src/pages/LeaderboardPage.tsx
@@ -3,185 +3,183 @@ import { Link } from 'react-router-dom';
 import Navbar from '../components/Navbar';
 import './LeaderboardPage.css';
 
-const REPO = 'Dev-Card/DevCard';
-const GITHUB_API = 'https://api.github.com';
-
-// Maintainers / accounts excluded from the contributor leaderboard.
-const EXCLUDED = new Set(
-  ['ShantKhatri', 'Harxhit', 'blankirigaya'].map((u) => u.toLowerCase())
-);
-
 type Contributor = {
-  login: string;
-  avatarUrl: string;
-  profileUrl: string;
-  issues: number;
-  mergedPrs: number;
-  openPrs: number;
+login: string;
+avatarUrl: string;
+profileUrl: string;
+issues: number;
+mergedPrs: number;
+openPrs: number;
 };
-
-type GithubContributor = {
-  login: string;
-  avatar_url: string;
-  html_url: string;
-  type: string;
-};
-
-type SearchResult = { total_count: number };
-
-async function ghJson<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
-    headers: { Accept: 'application/vnd.github+json' },
-  });
-  if (!response.ok) {
-    throw new Error(`GitHub request failed: ${response.status}`);
-  }
-  return response.json() as Promise<T>;
-}
-
-async function countSearch(query: string): Promise<number> {
-  const url = `${GITHUB_API}/search/issues?q=${encodeURIComponent(query)}&per_page=1`;
-  const result = await ghJson<SearchResult>(url);
-  return result.total_count;
-}
-
-async function loadContributorStats(login: string): Promise<Pick<Contributor, 'issues' | 'mergedPrs' | 'openPrs'>> {
-  const base = `repo:${REPO} author:${login}`;
-  const [issues, mergedPrs, openPrs] = await Promise.all([
-    countSearch(`${base} type:issue`),
-    countSearch(`${base} type:pr is:merged`),
-    countSearch(`${base} type:pr is:open`),
-  ]);
-  return { issues, mergedPrs, openPrs };
-}
 
 export default function LeaderboardPage() {
-  const [contributors, setContributors] = useState<Contributor[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+const [contributors, setContributors] = useState<Contributor[]>([]);
+const [loading, setLoading] = useState(true);
+const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    document.title = 'Contributor Leaderboard | DevCard';
-  }, []);
+useEffect(() => {
+document.title = 'Contributor Leaderboard | DevCard';
+}, []);
 
-  useEffect(() => {
-    let cancelled = false;
+useEffect(() => {
+let cancelled = false;
 
-    async function load() {
-      setLoading(true);
-      setError(null);
-      try {
-        const list = await ghJson<GithubContributor[]>(
-          `${GITHUB_API}/repos/${REPO}/contributors?per_page=100`
-        );
 
-        const eligible = list.filter(
-          (c) => c.type === 'User' && !EXCLUDED.has(c.login.toLowerCase())
-        );
+async function load() {
+  setLoading(true);
+  setError(null);
 
-        const enriched = await Promise.all(
-          eligible.map(async (c) => {
-            const stats = await loadContributorStats(c.login);
-            return {
-              login: c.login,
-              avatarUrl: c.avatar_url,
-              profileUrl: c.html_url,
-              ...stats,
-            } satisfies Contributor;
-          })
-        );
+  try {
+    const response = await fetch('/leaderboard.json', {
+      cache: 'no-store',
+    });
 
-        enriched.sort(
-          (a, b) =>
-            b.mergedPrs - a.mergedPrs ||
-            b.issues - a.issues ||
-            b.openPrs - a.openPrs ||
-            a.login.localeCompare(b.login)
-        );
-
-        if (!cancelled) setContributors(enriched);
-      } catch {
-        if (!cancelled) setError('Could not load contributors. GitHub may be rate-limiting — try again shortly.');
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
+    if (!response.ok) {
+      throw new Error('Failed to load leaderboard');
     }
 
-    load();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    const data: Contributor[] = await response.json();
 
-  return (
-    <>
-      <div className="bg-glow" />
-      <Navbar />
-      <main className="leaderboard" id="leaderboard-main">
-        <header className="leaderboard-header">
-          <div className="hero-badge">🏆 Community</div>
-          <h1>
-            <span className="gradient-text">Contributor</span> Leaderboard
-          </h1>
-          <p className="leaderboard-subtitle">
-            The developers building DevCard — ranked by merged pull requests, issues, and open work.
-          </p>
-        </header>
+    if (!cancelled) {
+      setContributors(data);
+    }
+  } catch {
+    if (!cancelled) {
+      console.error(error);
+      setError('Could not load leaderboard.');
+    }
+  } finally {
+    if (!cancelled) {
+      setLoading(false);
+    }
+  }
+}
 
-        {loading && (
-          <div className="leaderboard-state glass">Loading contributors…</div>
-        )}
+load();
 
-        {error && !loading && (
-          <div className="leaderboard-state glass error">{error}</div>
-        )}
+return () => {
+  cancelled = true;
+};
 
-        {!loading && !error && (
-          <ol className="leaderboard-list" id="leaderboard-list">
-            {contributors.map((c, i) => (
-              <li key={c.login} className="leaderboard-row glass">
-                <span className={`rank rank-${i + 1 <= 3 ? i + 1 : 'n'}`}>
-                  {i + 1}
+
+}, []);
+
+return (
+<> <div className="bg-glow" /> <Navbar />
+
+  <main className="leaderboard" id="leaderboard-main">
+    <header className="leaderboard-header">
+      <div className="hero-badge">🏆 Community</div>
+
+      <h1>
+        <span className="gradient-text">Contributor</span>{' '}
+        Leaderboard
+      </h1>
+
+      <p className="leaderboard-subtitle">
+        The developers building DevCard, ranked by merged
+        pull requests, issues, and open work.
+      </p>
+    </header>
+
+    {loading && (
+      <div className="leaderboard-state glass">
+        Loading contributors…
+      </div>
+    )}
+
+    {error && !loading && (
+      <div className="leaderboard-state glass error">
+        {error}
+      </div>
+    )}
+
+    {!loading && !error && (
+      <ol
+        className="leaderboard-list"
+        id="leaderboard-list"
+      >
+        {contributors.map((c, i) => (
+          <li
+            key={c.login}
+            className="leaderboard-row glass"
+          >
+            <span
+              className={`rank rank-${
+                i + 1 <= 3 ? i + 1 : 'n'
+              }`}
+            >
+              {i + 1}
+            </span>
+
+            <a
+              href={c.profileUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="contributor"
+            >
+              <img
+                src={c.avatarUrl}
+                alt={c.login}
+                className="contributor-avatar"
+                loading="lazy"
+              />
+
+              <span className="contributor-name">
+                @{c.login}
+              </span>
+            </a>
+
+            <div className="stats">
+              <span
+                className="stat"
+                title="Merged pull requests"
+              >
+                <span className="stat-value">
+                  {c.mergedPrs}
                 </span>
-                <a
-                  href={c.profileUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="contributor"
-                >
-                  <img
-                    src={c.avatarUrl}
-                    alt={c.login}
-                    className="contributor-avatar"
-                    loading="lazy"
-                  />
-                  <span className="contributor-name">@{c.login}</span>
-                </a>
-                <div className="stats">
-                  <span className="stat" title="Merged pull requests">
-                    <span className="stat-value">{c.mergedPrs}</span>
-                    <span className="stat-label">Merged PRs</span>
-                  </span>
-                  <span className="stat" title="Open pull requests">
-                    <span className="stat-value">{c.openPrs}</span>
-                    <span className="stat-label">Open PRs</span>
-                  </span>
-                  <span className="stat" title="Issues created">
-                    <span className="stat-value">{c.issues}</span>
-                    <span className="stat-label">Issues</span>
-                  </span>
-                </div>
-              </li>
-            ))}
-          </ol>
-        )}
 
-        <div className="leaderboard-footer">
-          <Link to="/" className="gradient-text">
-            ← Back to Home
-          </Link>
-        </div>
-      </main>
-    </>
-  );
+                <span className="stat-label">
+                  Merged PRs
+                </span>
+              </span>
+
+              <span
+                className="stat"
+                title="Open pull requests"
+              >
+                <span className="stat-value">
+                  {c.openPrs}
+                </span>
+
+                <span className="stat-label">
+                  Open PRs
+                </span>
+              </span>
+
+              <span
+                className="stat"
+                title="Issues created"
+              >
+                <span className="stat-value">
+                  {c.issues}
+                </span>
+
+                <span className="stat-label">
+                  Issues
+                </span>
+              </span>
+            </div>
+          </li>
+        ))}
+      </ol>
+    )}
+
+    <div className="leaderboard-footer">
+      <Link to="/" className="gradient-text">
+        ← Back to Home
+      </Link>
+    </div>
+  </main>
+</>);
 }


### PR DESCRIPTION
## Summary

Adds a **Contributor Leaderboard** to the web app (`apps/web`) as a new `/leaderboard` route and references it from the README Contributors section.

The leaderboard is now generated automatically via a **GitHub Actions workflow** and served as a static JSON file, eliminating GitHub API rate-limit issues in the client.

The page displays:

* Contributor **avatar image** and **GitHub username**
* **Issues created**
* **Merged PRs**
* **Open PRs**
* Ranking by **merged PRs → issues → open PRs**

Maintainer accounts (`@ShantKhatri`, `@Harxhit`, `@blankirigaya`) and bot accounts are excluded from the leaderboard.

## Changes

* `apps/web/src/pages/LeaderboardPage.tsx`

  * Added leaderboard page
  * Switched from direct GitHub API requests to consuming generated leaderboard data from `/leaderboard.json`

* `apps/web/src/App.tsx`

  * Added `/leaderboard` route

* `apps/web/public/leaderboard.json`

  * Generated leaderboard data consumed by the frontend

* `.github/workflows/update-leaderboard.yml`

  * New workflow to regenerate leaderboard data on a schedule and on demand

* `.github/scripts/generateLeaderboard.js`

  * Aggregates contributor statistics and writes leaderboard data

* `README.md`

  * Added leaderboard reference in the Contributors section

## Notes

* Leaderboard data is generated by GitHub Actions instead of being fetched from the GitHub API in the browser.
* This removes GitHub Search API rate-limit issues and reduces page load time.
* The workflow can be triggered manually using `workflow_dispatch` and also runs automatically on a schedule.

## Testing

### Local

1. Create or generate:

     ```txt
     apps/web/public/leaderboard.json
     ```
  ```bash
  [
    {
      "login": "Harxhit",
      "avatarUrl": "https://github.com/Harxhit.png",
      "profileUrl": "https://github.com/Harxhit",
      "mergedPrs": 42,
      "openPrs": 3,
      "issues": 12
    },
    {
      "login": "octocat",
      "avatarUrl": "https://github.com/octocat.png",
      "profileUrl": "https://github.com/octocat",
      "mergedPrs": 10,
      "openPrs": 2,
      "issues": 5
    }
  ]
  ```
2. Start the web app:

   ```bash
   npm dev
   ```

3. Verify:

   ```txt
   http://localhost:5173/leaderboard.json
   ```

   returns valid JSON.

4. Verify:

   ```txt
   http://localhost:5173/leaderboard
   ```

   renders the leaderboard correctly.

### GitHub Actions

1. Open the **Actions** tab.
2. Run **Update Leaderboard** manually.
3. Confirm the workflow completes successfully.
4. Verify `apps/web/public/leaderboard.json` is updated and committed.
5. Verify the deployed leaderboard reflects the updated data.

---

## Proof

<img width="1872" height="885" alt="2026-06-22_09-41-43" src="https://github.com/user-attachments/assets/4415a687-4193-4823-9ff8-1067a5a5b667" />

### Note: 
**This is not an actual representation(fake data).**
