### PR TITLE
fix(mobile): request camera permission on iOS to avoid blank screen

### DIFF
--- a/apps/mobile/src/screens/ScanScreen.tsx
+++ b/apps/mobile/src/screens/ScanScreen.tsx
@@ -10,6 +10,10 @@ import {
   Share,
   Platform,
   PermissionsAndroid,
+  Linking,
+  AppState,
+  type AppStateStatus,
+  NativeModules,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useFocusEffect } from '@react-navigation/native';
@@ -65,6 +69,33 @@ export default function ScanScreen({ navigation }: Props) {
     }
   };
 
+  const checkInitialCameraPermission = useCallback(async () => {
+    if (Platform.OS === 'android') {
+      const hasPerm = await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.CAMERA);
+      setHasPermission(hasPerm);
+    } else if (Platform.OS === 'ios') {
+      try {
+        const RNCameraKitModule = NativeModules.RNCameraKitModule;
+        if (RNCameraKitModule) {
+          const status = await RNCameraKitModule.checkDeviceCameraAuthorizationStatus();
+          if (status === true) {
+            setHasPermission(true);
+          } else if (status === -1) {
+            const granted = await RNCameraKitModule.requestDeviceCameraAuthorization();
+            setHasPermission(granted === true);
+          } else {
+            setHasPermission(false);
+          }
+        } else {
+          setHasPermission(true);
+        }
+      } catch (err) {
+        console.warn(err);
+        setHasPermission(false);
+      }
+    }
+  }, []);
+
   const requestCameraPermission = async () => {
     if (Platform.OS === 'android') {
       try {
@@ -82,10 +113,34 @@ export default function ScanScreen({ navigation }: Props) {
       } catch (err) {
         console.warn(err);
       }
-    } else {
-      // iOS permissions would typically be handled via react-native-permissions
-      // For this demo, assume true if not Android
-      setHasPermission(true);
+    } else if (Platform.OS === 'ios') {
+      try {
+        const RNCameraKitModule = NativeModules.RNCameraKitModule;
+        if (RNCameraKitModule) {
+          const status = await RNCameraKitModule.checkDeviceCameraAuthorizationStatus();
+          if (status === true) {
+            setHasPermission(true);
+          } else if (status === -1) {
+            const granted = await RNCameraKitModule.requestDeviceCameraAuthorization();
+            setHasPermission(granted === true);
+          } else {
+            setHasPermission(false);
+            Alert.alert(
+              'Camera Access Required',
+              'Please enable camera access in your device settings to scan QR codes.',
+              [
+                { text: 'Cancel', style: 'cancel' },
+                { text: 'Settings', onPress: () => Linking.openURL('app-settings:') },
+              ],
+            );
+          }
+        } else {
+          setHasPermission(true);
+        }
+      } catch (err) {
+        console.warn(err);
+        setHasPermission(false);
+      }
     }
   };
 
@@ -104,7 +159,7 @@ export default function ScanScreen({ navigation }: Props) {
           title: 'My DevCard QR',
           url: uri,
         });
-      } catch (err) {
+      } catch {
         Alert.alert('Error', 'Failed to save QR code');
       }
     }
@@ -126,7 +181,8 @@ export default function ScanScreen({ navigation }: Props) {
   useFocusEffect(
     useCallback(() => {
       fetchCards();
-    }, [fetchCards])
+      checkInitialCameraPermission();
+    }, [fetchCards, checkInitialCameraPermission])
   );
 
   useEffect(() => {
@@ -143,6 +199,19 @@ export default function ScanScreen({ navigation }: Props) {
 
     loadStoredCardId();
   }, []);
+
+  useEffect(() => {
+    const handleAppStateChange = (nextAppState: AppStateStatus) => {
+      if (nextAppState === 'active') {
+        checkInitialCameraPermission();
+      }
+    };
+
+    const subscription = AppState.addEventListener('change', handleAppStateChange);
+    return () => {
+      subscription.remove();
+    };
+  }, [checkInitialCameraPermission]);
 
   useEffect(() => {
     if (!hasLoadedStoredCard) return;


### PR DESCRIPTION
## Summary

This PR resolves the iOS camera permission handling issue in the mobile QR scanner screen. Previously, when the camera permission status was undetermined (`-1`), the screen assumed permission was granted and mounted the native `Camera` component. If the user subsequently denied permission in the iOS system dialog, the scanner area stayed blank without showing any error feedback or prompt to re-enable permissions in settings.

With this change, permission is requested programmatically first. If denied, the UI correctly transitions to a placeholder screen with a button that triggers a settings redirect dialog.

---
Closes : #610 
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- **`apps/mobile/src/screens/ScanScreen.tsx`**:
  - Imported `Linking`, `AppState`, `AppStateStatus`, and `NativeModules` from `react-native`.
  - Added a `checkInitialCameraPermission` function to check status and prompt for authorization programmatically using `RNCameraKitModule` if status is undetermined (`-1`).
  - Updated `requestCameraPermission` to show a user-friendly alert on iOS if permissions are denied, with a redirect link directly to iOS App Settings.
  - Added an `AppState` listener to automatically re-evaluate camera permission status when the user returns to the app from iOS Settings.
  - Fixed an ESLint warning for an unused `err` variable in `handleSaveQR`.

---

## How to Test

1. Open the mobile app on iOS.
2. Navigate to the Scan screen.
3. Deny camera permission when the iOS system dialog prompts.
4. Verify that the app shows the "Camera Permission Required" placeholder instead of a blank black screen.
5. Tap "Grant Permission" and click "Settings" to verify that the app redirects you to the iOS settings menu.

---

## Checklist

- [x] My code follows the project's coding style (`npm run lint` passes).
- [x] TypeScript compiles without errors (`npm run typecheck --workspaces --if-present`).
- [ ] I have added or updated tests for the changes I made.
- [x] All tests pass locally (`npm run test --workspaces --if-present`).
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description.
