### PR TITLE
fix(actions): correct leaderboard.json path in workflow

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -36,7 +36,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add public/leaderboard.json
+          git add apps/web/public/leaderboard.json
 
           if git diff --staged --quiet; then
             echo "No changes to commit"


### PR DESCRIPTION
## Summary

Fixes the leaderboard workflow by correcting the path used when staging `leaderboard.json` for commits. The workflow was generating the file in `apps/web/public/leaderboard.json` but attempting to add `public/leaderboard.json`, causing the action to fail.


