### PR TITLE
fix: use create-pull-request action for leaderboard updates

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
   issues: read
 
 jobs:
@@ -31,17 +31,13 @@ jobs:
             const script = require('./.github/scripts/generateLeaderboard.js');
             await script({ github, context });
 
-      - name: Commit leaderboard
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git add apps/web/public/leaderboard.json
-
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-            exit 0
-          fi
-
-          git commit -m "chore: update leaderboard"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update leaderboard"
+          title: "chore: update leaderboard"
+          body: "Automated update of contributor leaderboard data."
+          branch: "automation/leaderboard-update"
+          base: "main"
+          delete-branch: true


### PR DESCRIPTION
## Summary

The contributor leaderboard workflow currently fails because it tries to push updates directly to the main branch, which is protected. This pull request modifies the workflow to use the `peter-evans/create-pull-request` action. Instead of pushing to main, the workflow will now open an automated pull request with the updated leaderboard data.

Closes #641

---
## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [x] Infrastructure / DevOps
- [ ] Security

---
## What Changed

- Changed the `pull-requests` permission in `.github/workflows/leaderboard.yml` from `read` to `write` to allow the action to open pull requests.
- Replaced the manual git commit and push steps in `.github/workflows/leaderboard.yml` with the `peter-evans/create-pull-request` action.
---

## How to Test
1. Verify the changes by running the workflow in a repository with protected branches.
2. The workflow should run the script, find the modified `leaderboard.json` file, and open a pull request without any push block errors.

---
## Checklist
- [x] My code follows the project's coding style (`npm run lint` passes).
- [x] TypeScript compiles without errors (`npm run typecheck --workspaces --if-present`).
- [ ] I have added or updated tests for the changes I made.
- [x] All tests pass locally (`npm run test --workspaces --if-present`).
- [ ] I have updated documentation where necessary.
- [x] No new `console.log` or debug statements left in the code.
- [ ] Breaking changes are documented in this PR description.