### PR TITLE
fix(event): Added organiserId in response

### DIFF
--- a/apps/backend/src/routes/event.ts
+++ b/apps/backend/src/routes/event.ts
@@ -118,7 +118,7 @@ export async function eventRoutes(
                 where: { slug: paramsSlug },
                 include: {
                     _count: { select: { attendees: true } },
-                    organizer: { select: { username: true, displayName: true } },
+                    organizer: { select: {id: true,  username: true, displayName: true } },
                  },
             });
 

--- a/apps/backend/src/routes/event.ts
+++ b/apps/backend/src/routes/event.ts
@@ -130,6 +130,7 @@ export async function eventRoutes(
                 id: details.id,
                 name: details.name,
                 slug: details.slug,
+                organizerId: details.organizerId,
                 description: details.description,
                 location: details.location,
                 organizerUsername: details.organizer.username,


### PR DESCRIPTION
## Summary

Typecheck was failing because the organiserId was not added in the response. 