### PR TITLE
refactor: remove any usages and improve type safety in public routes

### DIFF
--- a/apps/backend/src/routes/public.ts
+++ b/apps/backend/src/routes/public.ts
@@ -1,14 +1,31 @@
-import * as publicService from '../services/publicService.js';
-import { generateQRBuffer, generateQRSvg } from '../utils/qr.js';
+import * as publicService from "../services/publicService.js";
+import { generateQRBuffer, generateQRSvg } from "../utils/qr.js";
 
-import type { FastifyContextConfig, FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
+import type { Prisma } from '@prisma/client';
+import type {
+  FastifyContextConfig,
+  FastifyInstance,
+  FastifyRequest,
+  FastifyReply,
+} from "fastify";
 
 // ── QR size bounds ────────────────────────────────────────────────────────────
 const MIN_QR_SIZE = 1;
 const MAX_QR_SIZE = 2048;
 
 // ── Cache constants ───────────────────────────────────────────────────────────
-const CACHE_CONTROL_HEADER = 'public, max-age=300, stale-while-revalidate=60';
+const CACHE_CONTROL_HEADER = "public, max-age=300, stale-while-revalidate=60";
+
+interface QrQuerystring {
+  format?: "png" | "svg";
+  size?: string;
+}
+
+type CardLinkWithPlatform = Prisma.CardLinkGetPayload<{
+  include: {
+    platformLink: true;
+  };
+}>;
 
 export async function publicRoutes(app: FastifyInstance): Promise<void> {
   // ─── Public Profile ───────────────────────────────────────────────────────
@@ -16,89 +33,111 @@ export async function publicRoutes(app: FastifyInstance): Promise<void> {
    * GET /api/u/:username
    * Returns the public profile information for a user.
    */
-  app.get('/:username', {
-    config: {
-      rateLimit: {
-        max: 100,
-        timeWindow: '1 minute',
+  app.get(
+    "/:username",
+    {
+      config: {
+        rateLimit: {
+          max: 100,
+          timeWindow: "1 minute",
+        },
       },
     },
-  }, async (request: FastifyRequest<{ Params: { username: string } }>, reply: FastifyReply) => {
-    const { username } = request.params;
+    async (
+      request: FastifyRequest<{ Params: { username: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const { username } = request.params;
 
-    // Soft auth: extract viewer id if token present.
-    // authenticatedUserId is used to detect self-views; viewerId is only set
-    // for other authenticated users so the service knows who is viewing.
-    let viewerId: string | null = null;
-    let authenticatedUserId: string | null = null;
-    try {
-      if (request.headers.authorization) {
-        const decoded = (await request.jwtVerify()) as { id?: string };
-        authenticatedUserId = decoded?.id ?? null;
-        viewerId = authenticatedUserId;
+      // Soft auth: extract viewer id if token present.
+      // authenticatedUserId is used to detect self-views; viewerId is only set
+      // for other authenticated users so the service knows who is viewing.
+      let viewerId: string | null = null;
+      let authenticatedUserId: string | null = null;
+      try {
+        if (request.headers.authorization) {
+          const decoded = (await request.jwtVerify()) as { id?: string };
+          authenticatedUserId = decoded?.id ?? null;
+          viewerId = authenticatedUserId;
+        }
+      } catch {
+        // ignored — treat as unauthenticated
       }
-    } catch {
-      // ignored — treat as unauthenticated
-    }
 
-    try {
-      const result = await publicService.getPublicProfile(app, username, viewerId, request, authenticatedUserId);
-      if (!result) {
-        return reply.status(404).send({ error: 'User not found' });
+      try {
+        const result = await publicService.getPublicProfile(
+          app,
+          username,
+          viewerId,
+          request,
+          authenticatedUserId,
+        );
+        if (!result) {
+          return reply.status(404).send({ error: "User not found" });
+        }
+        reply
+          .header("X-Cache", result.cached ? "HIT" : "MISS")
+          .header("Cache-Control", CACHE_CONTROL_HEADER);
+        return result.data;
+      } catch (err: unknown) {
+        app.log.error({ err }, "Failed to fetch public profile");
+        return reply.status(500).send({ error: "Internal server error" });
       }
-      reply.header('X-Cache', result.cached ? 'HIT' : 'MISS').header('Cache-Control', CACHE_CONTROL_HEADER);
-      return result.data;
-    } catch (err: unknown) {
-      app.log.error({ err }, 'Failed to fetch public profile');
-      return reply.status(500).send({ error: 'Internal server error' });
-    }
-  });
+    },
+  );
 
   /**
    * GET /api/public/card/:cardId
    * Returns public data for a shared card via its direct link.
    * Used for standalone card sharing (minimal owner info).
-  */
+   */
   // ─── Shared Card View (Direct) ───
 
-  app.get('/card/:cardId', {
-    config: {
-      rateLimit: {
-        max: 100,
-        timeWindow: '1 minute'
-      }
-    } as FastifyContextConfig
-  }, async (request: FastifyRequest<{ Params: { cardId: string } }>, reply: FastifyReply) => {
-    const { cardId } = request.params;
-
-    try {
-      const card = await publicService.getCardById(app, cardId);
-      if (!card) {
-        return reply.status(404).send({ error: 'Card not found' });
-      }
-      const response = {
-        id: card.id,
-        title: card.title,
-        owner: {
-          username: card.user.username,
-          displayName: card.user.displayName,
-          bio: card.user.bio,
-          avatarUrl: card.user.avatarUrl,
-          accentColor: card.user.accentColor,
+  app.get(
+    "/card/:cardId",
+    {
+      config: {
+        rateLimit: {
+          max: 100,
+          timeWindow: "1 minute",
         },
-        links: card.cardLinks.map((cl: any) => ({
-          id: cl.platformLink.id,
-          platform: cl.platformLink.platform,
-          username: cl.platformLink.username,
-          url: cl.platformLink.url,
-        })),
-      };
-      return response;
-    } catch (err: unknown) {
-      app.log.error({ err }, 'Failed to fetch shared card');
-      return reply.status(500).send({ error: 'Internal server error' });
-    }
-  });
+      } as FastifyContextConfig,
+    },
+    async (
+      request: FastifyRequest<{ Params: { cardId: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const { cardId } = request.params;
+
+      try {
+        const card = await publicService.getCardById(app, cardId);
+        if (!card) {
+          return reply.status(404).send({ error: "Card not found" });
+        }
+        const response = {
+          id: card.id,
+          title: card.title,
+          owner: {
+            username: card.user.username,
+            displayName: card.user.displayName,
+            bio: card.user.bio,
+            avatarUrl: card.user.avatarUrl,
+            accentColor: card.user.accentColor,
+          },
+          links: card.cardLinks.map((cl: CardLinkWithPlatform) => ({
+            id: cl.platformLink.id,
+            platform: cl.platformLink.platform,
+            username: cl.platformLink.username,
+            url: cl.platformLink.url,
+          })),
+        };
+        return response;
+      } catch (err: unknown) {
+        app.log.error({ err }, "Failed to fetch shared card");
+        return reply.status(500).send({ error: "Internal server error" });
+      }
+    },
+  );
 
   // ─── Public Card View ─────────────────────────────────────────────────────
   /**
@@ -106,120 +145,164 @@ export async function publicRoutes(app: FastifyInstance): Promise<void> {
    * Returns full owner profile + specific card data.
    * Used when viewing a card through username + cardId (e.g. QR code scans).
    */
-  app.get('/:username/card/:cardId', {
-    config: {
-      rateLimit: {
-        max: 100,
-        timeWindow: '1 minute',
+  app.get(
+    "/:username/card/:cardId",
+    {
+      config: {
+        rateLimit: {
+          max: 100,
+          timeWindow: "1 minute",
+        },
       },
     },
-  }, async (request: FastifyRequest<{ Params: { username: string; cardId: string } }>, reply: FastifyReply) => {
-    const { username, cardId } = request.params;
+    async (
+      request: FastifyRequest<{ Params: { username: string; cardId: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const { username, cardId } = request.params;
 
-    let viewerId: string | null = null;
-    let authenticatedUserId: string | null = null;
-    try {
-      if (request.headers.authorization) {
-        const decoded = (await request.jwtVerify()) as { id?: string };
-        authenticatedUserId = decoded?.id ?? null;
-        viewerId = authenticatedUserId;
+      let viewerId: string | null = null;
+      let authenticatedUserId: string | null = null;
+      try {
+        if (request.headers.authorization) {
+          const decoded = (await request.jwtVerify()) as { id?: string };
+          authenticatedUserId = decoded?.id ?? null;
+          viewerId = authenticatedUserId;
+        }
+      } catch {
+        // ignored
       }
-    } catch {
-      // ignored
-    }
 
-    try {
-      const result = await publicService.getUserCard(app, username, cardId, viewerId, request, authenticatedUserId);
-      if (result.notFound) {
-        return reply.status(404).send({ error: 'User or card not found' });
+      try {
+        const result = await publicService.getUserCard(
+          app,
+          username,
+          cardId,
+          viewerId,
+          request,
+          authenticatedUserId,
+        );
+        if (result.notFound) {
+          return reply.status(404).send({ error: "User or card not found" });
+        }
+        return result.data;
+      } catch (err: unknown) {
+        app.log.error({ err }, "Failed to fetch user card");
+        return reply.status(500).send({ error: "Internal server error" });
       }
-      return result.data;
-    } catch (err: unknown) {
-      app.log.error({ err }, 'Failed to fetch user card');
-      return reply.status(500).send({ error: 'Internal server error' });
-    }
-  });
+    },
+  );
 
   // ─── QR Session ──────────────────────────────────────────────────────────
-  app.get('/:username/qr-session', {
-    config: {
-      rateLimit: {
-        max: 30,
-        timeWindow: '1 minute'
-      }
-    } as FastifyContextConfig
-  }, async (request: FastifyRequest<{ Params: { username: string } }>, reply: FastifyReply) => {
-    const { username } = request.params;
+  app.get(
+    "/:username/qr-session",
+    {
+      config: {
+        rateLimit: {
+          max: 30,
+          timeWindow: "1 minute",
+        },
+      } as FastifyContextConfig,
+    },
+    async (
+      request: FastifyRequest<{ Params: { username: string } }>,
+      reply: FastifyReply,
+    ) => {
+      const { username } = request.params;
 
-    try {
-      const result = await publicService.getPublicProfile(app, username, null, request, null);
-      if (!result) {
-        return reply.status(404).send({ error: 'User not found' });
+      try {
+        const result = await publicService.getPublicProfile(
+          app,
+          username,
+          null,
+          request,
+          null,
+        );
+        if (!result) {
+          return reply.status(404).send({ error: "User not found" });
+        }
+        const snapshot = result.data;
+        const expiresIn = 600;
+        const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+        const token = app.jwt.sign(
+          { profile: snapshot, sub: username },
+          { expiresIn: "10m" },
+        );
+        reply.header("Cache-Control", CACHE_CONTROL_HEADER);
+        return { token, tokenType: "JWT", expiresIn, expiresAt };
+      } catch (err: unknown) {
+        app.log.error({ err }, "Failed to create qr-session");
+        return reply.status(500).send({ error: "Internal server error" });
       }
-      const snapshot = result.data;
-      const expiresIn = 600;
-      const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
-      const token = app.jwt.sign({ profile: snapshot, sub: username }, { expiresIn: '10m' });
-      reply.header('Cache-Control', CACHE_CONTROL_HEADER);
-      return { token, tokenType: 'JWT', expiresIn, expiresAt };
-    } catch (err: unknown) {
-      app.log.error({ err }, 'Failed to create qr-session');
-      return reply.status(500).send({ error: 'Internal server error' });
-    }
-  });
+    },
+  );
 
   // ─── QR Code Generation ───────────────────────────────────────────────────
 
-  app.get('/:username/qr', {
-    config: {
-      rateLimit: {
-        max: 50,
-        timeWindow: '1 minute'
+  app.get(
+    "/:username/qr",
+    {
+      config: {
+        rateLimit: {
+          max: 50,
+          timeWindow: "1 minute",
+        },
+      } as FastifyContextConfig,
+    },
+    async (
+      request: FastifyRequest<{
+        Params: { username: string };
+        Querystring: QrQuerystring;
+      }>,
+      reply: FastifyReply,
+    ) => {
+      const { username } = request.params;
+      const { format = "png", size: rawSize } = request.query;
+      const size = rawSize !== undefined ? parseInt(rawSize, 10) : 400;
+
+      if (!Number.isInteger(size) || size < MIN_QR_SIZE || size > MAX_QR_SIZE) {
+        return reply.status(400).send({
+          error: `QR size must be an integer between ${MIN_QR_SIZE} and ${MAX_QR_SIZE}`,
+        });
       }
-    } as FastifyContextConfig
-  }, async (request: FastifyRequest<{
-    Params: { username: string };
-    Querystring: { format?: string; size?: string };
-  }>, reply: FastifyReply) => {
-    const { username } = request.params;
-    const format = (request.query as any).format || 'png';
 
-    const rawSize = (request.query as any).size;
-    const size = rawSize !== undefined ? parseInt(rawSize, 10) : 400;
-
-    if (!Number.isInteger(size) || size < MIN_QR_SIZE || size > MAX_QR_SIZE) {
-      return reply.status(400).send({
-        error: `QR size must be an integer between ${MIN_QR_SIZE} and ${MAX_QR_SIZE}`,
+      const user = await app.prisma.user.findUnique({
+        where: { username },
       });
-    }
 
-    const user = await app.prisma.user.findUnique({
-      where: { username },
-    });
-
-    if (!user) {
-      return reply.status(404).send({ error: 'User not found' });
-    }
-
-    const profileUrl = `${process.env.PUBLIC_APP_URL}/u/${username}`;
-
-    try {
-      if (format === 'svg') {
-        const svg = await generateQRSvg(profileUrl, { width: size });
-        return reply
-          .header('Content-Type', 'image/svg+xml')
-          .header('Content-Disposition', `inline; filename="devcard-${username}.svg"`)
-          .send(svg);
+      if (!user) {
+        return reply.status(404).send({ error: "User not found" });
       }
 
-      const png = await generateQRBuffer(profileUrl, { width: size });
-      return reply
-        .header('Content-Type', 'image/png')
-        .header('Content-Disposition', `inline; filename="devcard-${username}.png"`)
-        .send(png);
-    } catch (error) {
-      app.log.error({ error, username, size, format }, 'QR generation failed');
-      return reply.status(500).send({ error: 'QR code generation failed' });
-    }
-  });
+      const profileUrl = `${process.env.PUBLIC_APP_URL}/u/${username}`;
+
+      try {
+        if (format === "svg") {
+          const svg = await generateQRSvg(profileUrl, { width: size });
+          return reply
+            .header("Content-Type", "image/svg+xml")
+            .header(
+              "Content-Disposition",
+              `inline; filename="devcard-${username}.svg"`,
+            )
+            .send(svg);
+        }
+
+        const png = await generateQRBuffer(profileUrl, { width: size });
+        return reply
+          .header("Content-Type", "image/png")
+          .header(
+            "Content-Disposition",
+            `inline; filename="devcard-${username}.png"`,
+          )
+          .send(png);
+      } catch (error) {
+        app.log.error(
+          { error, username, size, format },
+          "QR generation failed",
+        );
+        return reply.status(500).send({ error: "QR code generation failed" });
+      }
+    },
+  );
 }


### PR DESCRIPTION
**Summary**

Closes #553

Removes all `any` usages from `apps/backend/src/routes/public.ts` by introducing proper TypeScript types for query parameters and card link response mapping. No runtime behaviour is changed.

---

**Type of Change**

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no functional change)
- [ ] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

**What Changed**

- Added `QrQuerystring` interface (`{ format?: 'png' | 'svg'; size?: string }`) and typed the QR route's `FastifyRequest` with `Querystring: QrQuerystring`, replacing two `(request.query as any)` casts with direct `request.query.format` and `request.query.size` access
- Added `CardLinkWithPlatform` type via `Prisma.CardLinkGetPayload<{ include: { platformLink: true } }>`, replacing `(cl: any)` in the `/card/:cardId` response mapping with a proper generated Prisma type
- Added `import type { Prisma } from '@prisma/client'` to support the payload type — reuses the existing generated client, no new dependencies

---

**How to Test**

1. Run `npm run typecheck --workspaces --if-present` — should pass with no new errors
2. Run `npm run lint` — should pass
3. Hit `GET /api/u/:username/qr?format=svg&size=300` and `GET /api/public/card/:cardId` manually or via existing tests to confirm responses are unchanged

---

**Checklist**

- [x] My code follows the project's coding style (`npm run lint` passes)
- [ ] TypeScript compiles without errors (`npm run typecheck --workspaces --if-present`)
- [ ] I have added or updated tests for the changes I made
- [x] All tests pass locally (`npm run test --workspaces --if-present`)
- [x] No new `console.log` or debug statements left in the code
- [x] Breaking changes are documented in this PR description

---

**Screenshots / Recordings**

*Not applicable — refactor only, no UI or API contract changes.*

---

**Note for reviewers:** Two pre-existing TypeScript errors (`rateLimit does not exist in type FastifyContextConfig`, lines 40 and 152) are visible in the Problems panel but were present before this PR and are out of scope for this issue.