### PR TITLE
Fix/leaderboard bot author

### DIFF
--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -41,6 +41,5 @@ jobs:
           branch: "automation/leaderboard-update"
           base: "main"
           delete-branch: true
-
-            author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-    committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+          committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"

--- a/.github/workflows/leaderboard.yml
+++ b/.github/workflows/leaderboard.yml
@@ -41,3 +41,6 @@ jobs:
           branch: "automation/leaderboard-update"
           base: "main"
           delete-branch: true
+
+            author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+    committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"


### PR DESCRIPTION
## Summary

This PR updates the automated leaderboard workflow to use `github-actions[bot]` as the commit author and committer instead of the contributor's identity. This ensures commits generated by the automation are correctly attributed to the GitHub Actions bot.


